### PR TITLE
Add pytest suite and configuration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+extend-exclude = ["external"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import sys
+import types
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_open_webui(monkeypatch):
+    """Provide a minimal stub of the ``open_webui.models.chats`` module."""
+    dummy_chat = {"history": {"currentId": None, "messages": {}}}
+
+    def get_chat_by_id(_):
+        return types.SimpleNamespace(chat=dummy_chat)
+
+    chats_mod = types.ModuleType("open_webui.models.chats")
+    chats_mod.Chats = types.SimpleNamespace(get_chat_by_id=get_chat_by_id)
+
+    monkeypatch.setitem(sys.modules, "open_webui", types.ModuleType("open_webui"))
+    monkeypatch.setitem(sys.modules, "open_webui.models", types.ModuleType("open_webui.models"))
+    monkeypatch.setitem(sys.modules, "open_webui.models.chats", chats_mod)
+
+    yield dummy_chat

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,40 @@
+from openwebui_devtoolkit.pipes.openai_responses_api_pipeline import (
+    build_responses_payload,
+    prepare_tools,
+    pretty_log_block,
+)
+
+
+def test_prepare_tools_variants():
+    reg = {
+        'tools': {
+            'one': {'spec': {'name': 'foo', 'description': 'd', 'parameters': {'type': 'object'}}},
+            'two': {'spec': {'function': {'name': 'bar'}}},
+        }
+    }
+    tools = prepare_tools(reg)
+    assert tools[0]['name'] == 'foo'
+    assert tools[1]['name'] == 'bar'
+    assert tools[0]['type'] == tools[1]['type'] == 'function'
+
+
+def test_build_responses_payload(stub_open_webui):
+    stub_open_webui['history'] = {
+        'currentId': 'm2',
+        'messages': {
+            'm1': {'role': 'user', 'content': [{'text': 'hi'}], 'parentId': None},
+            'm2': {'role': 'assistant', 'content': [{'text': 'hello'}], 'parentId': 'm1'},
+        },
+    }
+
+    payload = build_responses_payload('chat1')
+    assert payload == [
+        {'role': 'user', 'content': [{'type': 'input_text', 'text': 'hi'}]},
+        {'role': 'assistant', 'content': [{'type': 'output_text', 'text': 'hello'}]},
+    ]
+
+
+def test_pretty_log_block():
+    out = pretty_log_block({'a': 1}, label='lbl')
+    assert 'lbl =' in out
+    assert '{\n  "a": 1\n}' in out

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+from scripts.publish_to_webui import (
+    _detect_type,
+    _extract_metadata,
+    _build_payload,
+    _post,
+)
+
+
+def test_detect_type_from_path():
+    assert _detect_type(Path('src/openwebui_devtoolkit/pipes/tool.py'), None) == 'pipe'
+    assert _detect_type(Path('any/filters/foo.py'), None) == 'filter'
+    assert _detect_type(Path('toolz/tools/x.py'), None) == 'tool'
+    assert _detect_type(Path('some/other/path.py'), 'filter') == 'filter'
+
+
+def test_extract_metadata_success():
+    code = 'id: test\ndescription: cool plugin\nprint(1)'
+    pid, desc = _extract_metadata(code)
+    assert pid == 'test'
+    assert desc == 'cool plugin'
+
+
+def test_extract_metadata_missing_id():
+    with pytest.raises(ValueError):
+        _extract_metadata('description: nope')
+
+
+def test_build_payload_structure():
+    payload = _build_payload('pid', 'pipe', 'code', 'desc')
+    assert payload['id'] == 'pid'
+    assert payload['type'] == 'pipe'
+    assert payload['content'] == 'code'
+    assert payload['meta']['description'] == 'desc'
+
+
+class DummyResp:
+    def __init__(self, code=200):
+        self._code = code
+
+    def getcode(self):
+        return self._code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_post_success(monkeypatch):
+    def mock_urlopen(req, timeout=30):
+        return DummyResp(201)
+
+    monkeypatch.setattr('scripts.publish_to_webui.urlopen', mock_urlopen)
+    status = _post('http://x', 'k', '/create', {'a': 1})
+    assert status == 201
+
+
+def test_post_http_error(monkeypatch):
+    def mock_urlopen(req, timeout=30):
+        raise HTTPError(req.full_url, 400, 'oops', hdrs=None, fp=None)
+
+    monkeypatch.setattr('scripts.publish_to_webui.urlopen', mock_urlopen)
+    status = _post('http://x', 'k', '/create', {'a': 1})
+    assert status == 400
+


### PR DESCRIPTION
## Summary
- add .ruff config to ignore vendored code
- add pytest fixtures for open_webui stubs
- add tests for helper script functions
- add tests for openai_responses_api_pipeline helpers

## Testing
- `ruff check .`
- `pytest -q` *(fails: `pytest` not installed)*