### PR TITLE
Improve testing harness and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,17 +29,13 @@ inside that path.
 ---
 
 ## Tests
-Run the test suite with Python’s ``unittest`` module:
+Run lint and unit tests with the helper script:
 
 ```bash
-python -m unittest discover -s tests -v
+bash scripts/test.sh
 ```
 
-All PRs should ensure this command succeeds.
-
-To lint the codebase, run:
-
-```bash
-ruff check .
-```
+All PRs should ensure this command succeeds. The script sets ``PYTHONPATH`` so
+tests can import from ``src/`` and then runs ``ruff check .`` followed by
+``python -m unittest discover -s tests -v``.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Self-contained **Pipes**, **Filters**, and **Tools** you can copy-paste into
 ```bash
 # local dev
 pip install -e '.[dev]'
-python -m unittest discover -s tests -v
-ruff check .
+bash scripts/test.sh
 ```
+
+The script sets ``PYTHONPATH`` so tests can import from ``src/`` and runs
+``ruff`` followed by the unit tests.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lint the codebase first
+# Ensure src/ is on PYTHONPATH for unit tests
+export PYTHONPATH="$(pwd)/src:${PYTHONPATH:-}"
+ruff check .
+# Run the test suite
+python -m unittest discover -s tests -v

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,7 @@
 import sys
-from pathlib import Path
 import types
 import unittest
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 sys.modules.setdefault("httpx", types.ModuleType("httpx"))
 dummy_chats_mod = types.ModuleType("open_webui.models.chats")
 dummy_chats_mod.Chats = types.SimpleNamespace(get_chat_by_id=lambda _ : None)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,11 +1,8 @@
 from pathlib import Path
 from urllib.error import HTTPError
 
-import sys
 import unittest
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from scripts.publish_to_webui import (
     _detect_type,


### PR DESCRIPTION
## Summary
- add a `scripts/test.sh` helper that runs `ruff` and unit tests
- rely on the helper from the README
- update agent instructions on running tests
- streamline test files to use `PYTHONPATH` from script

## Testing
- `bash scripts/test.sh`