### PR TITLE
Add pytest dependency and update scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,16 @@ description = "Self-contained Pipes, Filters & Tools for Open WebUI"
 readme = "README.md"
 requires-python = ">=3.11"
 
+[project.dependencies]
+httpx = "*"
+fastapi = "*"
+pydantic = "*"
+
 [project.optional-dependencies]
 dev = [
-  "requests"
+  "requests",
+  "ruff",
+  "pytest",
 ]
 
 [build-system]

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -7,7 +7,7 @@ if [ ! -s external/open-webui/.git ]; then
 fi
 
 echo "▶ Installing runtime dependencies …"
-pip install --quiet ruff httpx fastapi pydantic
+pip install --quiet ruff httpx fastapi pydantic pytest
 
 echo "▶ Installing toolkit in editable mode …"
 pip install -e '.[dev]' --quiet

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,5 +5,9 @@ set -euo pipefail
 # Ensure src/ is on PYTHONPATH for unit tests
 export PYTHONPATH="$(pwd)/src:${PYTHONPATH:-}"
 ruff check .
-# Run the test suite
+# Run the unittest suite
 python -m unittest discover -s tests -v
+# Also run pytest for extensibility if available
+if command -v pytest >/dev/null 2>&1; then
+    pytest -v
+fi


### PR DESCRIPTION
## Summary
- declare runtime deps: httpx, fastapi and pydantic
- extend dev deps to include ruff and pytest
- ensure startup installs pytest
- run pytest in `scripts/test.sh` when available

## Testing
- `bash scripts/test.sh`