### PR TITLE
Adjust CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- keep CI from running twice by only triggering on pull requests

## Testing
- `nox -s lint tests`
