### PR TITLE
Add advanced extension examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ out `open_webui` so the suite can run without the external project.
 
 ## Examples
 
-Minimal example extensions are provided under `examples/`.
-Each subfolder (`pipes/`, `filters/`, `tools/`) contains a template
-showing how the corresponding feature works.
+Minimal example extensions live under `examples/`.
+Each subfolder (`pipes/`, `filters/`, `tools/`) contains starter templates.
+Additional files demonstrate advanced features discovered in the
+`open-webui` code base:
+
+- `pipes/status_stream_pipe.py` streams tokens and emits status events.
+- `filters/stream_logging_filter.py` shows the optional `stream` hook.
+- `tools/docstring_tools.py` builds tool specs from function docstrings.

--- a/examples/filters/filter_template.py
+++ b/examples/filters/filter_template.py
@@ -1,7 +1,10 @@
 """
 title: Filter Template
 id: filter_template
-description: Demonstrates inlet/outlet hooks and per-user valves.
+description: |
+    Demonstrates inlet/outlet hooks and per-user valves. The optional
+    ``stream`` method can inspect events during generation just like in
+    `open-webui`.
 author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions

--- a/examples/filters/stream_logging_filter.py
+++ b/examples/filters/stream_logging_filter.py
@@ -1,0 +1,35 @@
+"""
+title: Stream Logging Filter
+id: stream_logging_filter
+description: Demonstrates the optional ``stream`` hook for filters.
+author: open-webui
+license: MIT
+version: 0.0.0
+"""
+
+from typing import Any, Awaitable, Callable
+from pydantic import BaseModel, Field
+
+
+class Filter:
+    class Valves(BaseModel):
+        priority: int = Field(0, description="Execution priority")
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+
+    def inlet(self, body: dict, __user__: dict | None = None) -> dict:
+        print("[stream_logging] inlet:", body)
+        return body
+
+    async def stream(self, event: dict[str, Any]) -> dict[str, Any]:
+        print("[stream_logging] event:", event.get("type"))
+        return event
+
+    async def outlet(
+        self,
+        body: dict,
+        __event_emitter__: Callable[[dict], Awaitable[None]],
+    ) -> dict:
+        print("[stream_logging] outlet:", body)
+        return body

--- a/examples/pipes/pipe_template.py
+++ b/examples/pipes/pipe_template.py
@@ -1,8 +1,10 @@
 """
 title: Pipe Function Template
 id: pipe_template
-description: Starting point for custom pipelines. Demonstrates valves, user
-    overrides and event emitters.
+description: |
+    Starting point for custom pipelines. Demonstrates valves, user overrides,
+    event emitters and access to request metadata as seen in the
+    ``open-webui`` code base.
 author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions

--- a/examples/pipes/status_stream_pipe.py
+++ b/examples/pipes/status_stream_pipe.py
@@ -1,0 +1,44 @@
+"""
+title: Status Stream Pipe
+id: status_stream_pipe
+description: Streams words with status events to demonstrate event emitters.
+author: open-webui
+license: MIT
+version: 0.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncGenerator, Awaitable, Callable
+from pydantic import BaseModel, Field
+from fastapi import Request
+
+
+class Pipe:
+    class Valves(BaseModel):
+        DELAY: float = Field(0.1, description="Delay between tokens in seconds")
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+
+    async def pipe(
+        self,
+        body: dict[str, Any],
+        __user__: dict,
+        __request__: Request,
+        __event_emitter__: Callable[[dict], Awaitable[None]],
+        __event_call__: Callable[[dict[str, Any]], Awaitable[Any]],
+        __task__: str,
+        __task_body__: dict[str, Any],
+        __files__: list[dict[str, Any]],
+        __metadata__: dict[str, Any],
+        __tools__: list[Any],
+    ) -> AsyncGenerator[str, None]:
+        text = body.get("prompt", "Hello world").split()
+        for idx, word in enumerate(text, 1):
+            await __event_emitter__({"type": "status", "data": {"description": f"Token {idx}", "done": False}})
+            yield word + " "
+            await asyncio.sleep(self.valves.DELAY)
+        await __event_emitter__({"type": "status", "data": {"description": "Complete", "done": True}})
+        return

--- a/examples/tools/docstring_tools.py
+++ b/examples/tools/docstring_tools.py
@@ -1,0 +1,47 @@
+"""
+title: Docstring Tools
+id: docstring_tools
+description: Generate tool specs from function docstrings.
+author: open-webui
+license: MIT
+version: 0.0.0
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import get_type_hints, Any
+
+from pydantic import BaseModel
+
+
+def _spec_from_function(fn: Any) -> dict:
+    """Build a tool spec from ``fn``'s signature and docstring."""
+    hints = get_type_hints(fn)
+    doc = inspect.getdoc(fn) or ""
+    desc = doc.splitlines()[0] if doc else fn.__name__
+    params = {
+        name: {"type": "string", "description": hints.get(name, str).__name__}
+        for name in hints
+        if name != "return"
+    }
+    return {
+        "name": fn.__name__,
+        "description": desc,
+        "parameters": {"type": "object", "properties": params},
+    }
+
+
+class Tool:
+    class Valves(BaseModel):
+        pass
+
+    async def echo(self, text: str) -> str:
+        """Echo back ``text``."""
+        return text
+
+    async def add(self, a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    specs = [_spec_from_function(echo), _spec_from_function(add)]

--- a/examples/tools/tool_template.py
+++ b/examples/tools/tool_template.py
@@ -1,7 +1,10 @@
 """
 title: Tool Template
 id: tool_template
-description: Example toolkit with multiple functions and Pydantic specs.
+description: |
+    Example toolkit with multiple functions and Pydantic specs. Inspired by the
+    `open-webui` tool loader, this file shows how a Tool class exposes
+    callable functions and schema metadata.
 author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions


### PR DESCRIPTION
## Summary
- extend README with new example references
- mention metadata hooks in pipe and tool templates
- mention stream support in filter template
- add a status stream pipe example
- add a stream logging filter example
- add a docstring-based tool example

## Testing
- `nox -s lint tests`