### PR TITLE
Fix universal_example parameter type

### DIFF
--- a/examples/tools/universal_example.py
+++ b/examples/tools/universal_example.py
@@ -83,7 +83,7 @@ class Tools:
     # ------------------------------------------------------------------
     async def get_weather(
         self,
-        city: Optional[str] = None,
+        city: str = "",
         __event_emitter__: Optional[Callable[[dict], Awaitable[None]]] = None,
         __event_call__: Optional[Callable[[dict], Awaitable[Any]]] = None,
     ) -> str:


### PR DESCRIPTION
## Summary
- ensure `get_weather` uses a string parameter

## Testing
- `nox -s lint tests`