### PR TITLE
Improve event emitter example

### DIFF
--- a/examples/tools/event_emitter_example.py
+++ b/examples/tools/event_emitter_example.py
@@ -1,40 +1,33 @@
 """
 title: Event Emitter Example
 author: Open-WebUI Docs Team
-version: 1.1
+version: 1.2
 license: MIT
 description: |
-  This tool demonstrates how to use Open WebUI's built‑in event system to
-  communicate with the UI during tool execution.  Events are surfaced through
-  two special parameters that are injected into tool functions at runtime:
+  This tool demonstrates how to use Open WebUI's event system.  Tool
+  functions receive two injected parameters at runtime:
 
-  • ``__event_emitter__`` – Sends non‑blocking updates to the UI.  ``Chat.svelte``
-    listens for these ``chat-events`` via a websocket and updates the current
-    message accordingly.
-
-    Common ``type`` values handled in the client:
-      - ``status`` – update progress indicators.
-      - ``message`` or ``chat:message:delta`` – append streamed text to the
-        current message.
-      - ``chat:message`` or ``replace`` – replace the entire message content.
+  • ``__event_emitter__`` – Sends non‑blocking updates over the
+    ``chat-events`` websocket.  ``Chat.svelte`` maps the ``type`` field of each
+    event to UI actions:
+      - ``status`` – progress indicator updates.
+      - ``message`` or ``chat:message:delta`` – append text to the current
+        message bubble.
+      - ``chat:message`` or ``replace`` – replace the bubble content.
       - ``files`` or ``chat:message:files`` – attach file metadata.
-      - ``citation`` or ``source`` – add collapsible source blocks or code
-        execution results.
+      - ``citation`` or ``source`` – add collapsible source blocks.
       - ``chat:title`` – rename the chat.
-      - ``chat:tags`` – refresh chat tags in the sidebar.
+      - ``chat:tags`` – refresh sidebar tags.
       - ``notification`` – show a toast (``info``, ``success``, ``warning`` or
         ``error``).
 
-  • ``__event_call__`` – Opens a confirmation/input dialog in the UI and waits
-    for the user's response.  ``Chat.svelte`` exposes ``confirmation`` and
-    ``input`` types that resolve to the value entered or ``True/False`` for
-    confirmation dialogs.  ``execute`` events can also run arbitrary client-side
-    JavaScript and return the result.
+  • ``__event_call__`` – Opens a modal and waits for user input.  Supported
+    ``type`` values are ``confirmation`` and ``input`` (both return the
+    user's response) and ``execute`` to run client-side JavaScript.
 
-  Additionally ``Chat.svelte`` defines an ``EventTarget`` for voice features. It
-  dispatches ``chat:start``, ``chat`` and ``chat:finish`` events while a message
-  is streaming.  Components like ``CallOverlay.svelte`` subscribe to these events
-  to drive real-time text-to-speech playback.
+  ``Chat.svelte`` also exposes an ``EventTarget`` for voice features. It
+  dispatches ``chat:start``, ``chat`` and ``chat:finish`` events while streaming
+  so other components can play text-to-speech audio in real time.
 """
 
 from __future__ import annotations
@@ -72,6 +65,12 @@ class Tools:
         total = units if isinstance(units, int) and units > 0 else self.valves.units
 
         # 1) initial chat stub + progress bar
+        await emit(
+            {
+                "type": "notification",
+                "data": {"type": "info", "content": "Starting demo"},
+            }
+        )
         await emit({"type": "message", "data": {"content": "⏳ *Demo starting…*"}})
         await emit(
             {
@@ -168,6 +167,13 @@ class Tools:
                     "done": True,
                     "style": "success",
                 },
+            }
+        )
+
+        await emit(
+            {
+                "type": "notification",
+                "data": {"type": "success", "content": "Demo finished"},
             }
         )
 


### PR DESCRIPTION
## Summary
- document event emitter handling in `Chat.svelte`
- show `notification` events when starting and finishing the demo

## Testing
- `nox -s lint tests`