### PR TITLE
Improve event emitter example

### DIFF
--- a/examples/tools/event_emitter_example.py
+++ b/examples/tools/event_emitter_example.py
@@ -1,36 +1,22 @@
 """
 title: Event Emitter Example
 author: Open-WebUI Docs Team
-version: 1.5
+version: 2.0
 license: MIT
 description: |
-  Demonstrates how tools can drive the WebUI in real time.
-  Functions receive two special parameters:
+  A concise tour of Open WebUI’s event system. Tools emit events to the
+  front‑end via ``__event_emitter__`` and ``__event_call__``.
+  Core ``type`` values include:
+    - ``status`` – progress bar updates
+    - ``message``/``chat:message:delta`` – append text to the bubble
+    - ``chat:message``/``replace`` – replace message contents
+    - ``citation``/``source`` – collapsible source blocks
+    - ``notification`` – toast popups
+    - ``confirmation``/``input`` – blocking modals for user feedback
+    - ``execute`` – run arbitrary JavaScript in the browser
 
-  • ``__event_emitter__`` – Sends non-blocking UI events over the
-    ``chat-events`` websocket. ``Chat.svelte`` handles the following ``type``
-    values:
-      - ``status`` – update the progress bar.
-      - ``message`` / ``chat:message:delta`` – append text to the current
-        bubble.
-      - ``chat:message`` / ``replace`` – replace the message contents.
-      - ``files`` / ``chat:message:files`` – attach file metadata.
-      - ``citation`` / ``source`` – add collapsible source blocks (use
-        ``data.type == 'code_execution'`` for interpreter results).
-      - ``chat:title`` – rename the chat.
-      - ``chat:tags`` – refresh sidebar tags.
-      - ``notification`` – toast (``info``/``success``/``warning``/``error``).
-      - ``chat:completion`` – stream model tokens; also emits voice events
-        (``chat:start`` → ``chat`` → ``chat:finish``).
-      - ``execute`` – run JavaScript (non-blocking) without waiting
-        for the result.
-
-  • ``__event_call__`` – Opens a blocking modal. ``type`` values:
-      ``confirmation`` or ``input`` (returns the user response)
-      and ``execute`` (returns the JS result).
-
-  This sample inserts a floating banner via ``execute`` and updates it
-  as work progresses. The banner is removed once processing completes.
+  This example walks through each event with confirmations between steps
+  and cleans up a temporary banner when finished.
 """
 
 from __future__ import annotations
@@ -54,233 +40,110 @@ class Tools:
     def __init__(self):
         self.valves = self.Valves()
 
-    # Public tool method  –  shows every event type in order
+    # Public tool method demonstrating common event types
     async def playground(
         self,
-        units: int = None,
+        units: int | None = None,
         __event_emitter__: Emitter | None = None,
         __event_call__: Caller | None = None,
     ) -> str:
 
-        async def emit(evt: Dict):  # await emit({...})
+        async def emit(evt: Dict) -> None:
             if __event_emitter__:
                 await __event_emitter__(evt)
 
+        async def confirm(msg: str) -> bool:
+            if __event_call__:
+                return await __event_call__({"type": "confirmation", "data": {"title": "Event Demo", "message": msg}})
+            return True
+
+        async def run_js(code: str) -> any:
+            if __event_call__:
+                return await __event_call__({"type": "execute", "data": {"code": code}})
+            return None
+
         total = units if isinstance(units, int) and units > 0 else self.valves.units
 
-        # 1) initial chat stub + progress bar
-        await emit(
-            {
-                "type": "notification",
-                "data": {"type": "info", "content": "Starting demo"},
-            }
-        )
-        await emit({"type": "message", "data": {"content": "⏳ *Demo starting…*"}})
-        # HTML is allowed inside markdown messages
-        await emit({"type": "message", "data": {"content": "<b>HTML demo:</b> <em>Hello WebUI</em>"}})
+        await emit({"type": "notification", "data": {"type": "info", "content": "Starting demo"}})
+        await emit({"type": "message", "data": {"content": "🧪 Beginning event demo."}})
 
-        # Create a floating banner that will show live progress
-        if __event_call__:
-            await __event_call__(
-                {
-                    "type": "execute",
-                    "data": {
-                        "code": """
+        # --- banner ------------------------------------------------------
+        await run_js(
+            """
 if (!document.getElementById('demo-banner')) {
   const div = document.createElement('div');
   div.id = 'demo-banner';
-  div.style.cssText = 'position:fixed;top:10px;right:10px;padding:8px;background:#ffc;border:1px solid #444;z-index:1000;';
-  div.textContent = 'Starting...';
+  div.style.cssText = 'position:fixed;top:8px;left:50%;transform:translateX(-50%);padding:6px 12px;background:#bef264;border-radius:6px;font-weight:bold;z-index:9999';
+  div.textContent = 'Event demo running...';
   document.body.appendChild(div);
 }
-return 'banner ready';
 """
-                    },
-                }
-            )
-        await emit(
-            {
-                "type": "status",
-                "data": {"description": f"🚀 {total} units", "done": False},
-            }
         )
 
+        if not await confirm("Banner added. Continue with progress demo?"):
+            await run_js("document.getElementById('demo-banner')?.remove();")
+            return "Demo cancelled."
+
+        # --- status updates ---------------------------------------------
+        await emit({"type": "status", "data": {"description": "Progress", "done": False}})
         for idx in range(1, total + 1):
             await asyncio.sleep(self.valves.delay)
-            await emit(
-                {
-                    "type": "status",
-                    "data": {"description": f"…unit {idx}/{total}", "done": False},
-                }
-            )
-            if __event_call__:
-                await __event_call__(
-                    {
-                        "type": "execute",
-                        "data": {
-                            "code": f"document.getElementById('demo-banner').textContent = 'Unit {idx}/{total}';"
-                        },
-                    }
-                )
-            # Stream delta text to the current bubble
-            await emit({"type": "chat:message:delta", "data": {"content": f" {idx}"}})
+            await emit({"type": "status", "data": {"description": f"Step {idx}/{total}", "done": False}})
+            await run_js(f"document.getElementById('demo-banner').textContent = 'Step {idx} of {total}';")
+        await emit({"type": "status", "data": {"description": "Progress complete", "done": True, "style": "success"}})
 
-            # Mid-way:  input   →   confirmation
-            if idx == total // 2 and __event_call__:
-                note = (
-                    await __event_call__(
-                        {
-                            "type": "input",
-                            "data": {
-                                "title": "Add a note (optional)",
-                                "message": "Enter text to inject or leave blank",
-                                "placeholder": "my note",
-                            },
-                        }
-                    )
-                    or ""
-                )
+        if not await confirm("Progress complete. Provide a note?"):
+            await run_js("document.getElementById('demo-banner')?.remove();")
+            return "Demo cancelled."
 
-                proceed = await __event_call__(
-                    {
-                        "type": "confirmation",
-                        "data": {
-                            "title": "Continue?",
-                            "message": f"We’re at {idx}/{total}. Proceed?",
-                        },
-                    }
-                )
+        note = ""
+        if __event_call__:
+            note = await __event_call__({
+                "type": "input",
+                "data": {
+                    "title": "Optional note",
+                    "message": "Enter text to display in the chat",
+                    "placeholder": "my note",
+                },
+            }) or ""
 
-                if not proceed:  # user aborted
-                    await emit(
-                        {
-                            "type": "message",
-                            "data": {
-                                "content": "⚠️ Cancelled by user",
-                                "style": "warning",
-                            },
-                        }
-                    )
-                    await emit(
-                        {
-                            "type": "status",
-                            "data": {
-                                "description": "cancelled",
-                                "done": True,
-                                "hidden": True,
-                            },
-                        }
-                    )
-                    return "User cancelled."
-                if note:
-                    await emit(
-                        {
-                            "type": "message",
-                            "data": {"content": f"📝 Note saved: {note}"},
-                        }
-                    )
+        if note:
+            await emit({"type": "message", "data": {"content": f"📝 Note: {note}"}})
 
-                # Execute arbitrary JavaScript in the user's browser
-                result = await __event_call__(
-                    {
-                        "type": "execute",
-                        "data": {"code": "return 2 + 2"},
-                    }
-                )
-                await emit(
-                    {
-                        "type": "message",
-                        "data": {"content": f"🔢 JS returned: {result}"},
-                    }
-                )
+        if not await confirm("Show HTML rendering example?"):
+            await run_js("document.getElementById('demo-banner')?.remove();")
+            return "Demo cancelled."
 
+        # --- HTML message -----------------------------------------------
+        await emit({"type": "chat:message", "data": {"content": "<b>Bold</b> <i>HTML</i> demo"}})
 
-                # Update banner via JavaScript
-                await __event_call__(
-                    {
-                        "type": "execute",
-                        "data": {
-                            "code": f"document.getElementById('demo-banner').textContent = 'Halfway there ({idx}/{total})';"
-                        },
-                    }
-                )
+        js_result = await run_js("return 2 + 2")
+        await emit({"type": "message", "data": {"content": f"🔢 JS result: {js_result}"}})
 
-        # Emit tokens one by one using chat:completion
-        stream_text = "Streaming via chat:completion"
-        for char in stream_text:
-            await asyncio.sleep(0.05)
-            await emit(
-                {
-                    "type": "chat:completion",
-                    "data": {"choices": [{"delta": {"content": char}}]},
-                }
-            )
-        await emit(
-            {
-                "type": "chat:completion",
-                "data": {"done": True, "choices": [{"message": {"content": stream_text}}]},
-            }
-        )
+        if not await confirm("Show citation example?"):
+            await run_js("document.getElementById('demo-banner')?.remove();")
+            return "Demo cancelled."
 
-        # citation + finished bar + in-place bubble edit
+        # --- citation ----------------------------------------------------
         await emit(
             {
                 "type": "citation",
                 "data": {
-                    "document": [f"Demo processed **{total}** units."],
-                    "metadata": [
-                        {"date_accessed": time.strftime("%Y-%m-%dT%H:%M:%SZ")}
-                    ],
-                    "source": {
-                        "name": "Event Playground Tool",
-                        "url": "https://github.com/open-webui/open-webui",
-                    },
+                    "document": ["This text came from a *citation*."],
+                    "metadata": [{"date_accessed": time.strftime("%Y-%m-%dT%H:%M:%SZ")}],
+                    "source": {"name": "Event Demo", "url": "https://github.com/open-webui/open-webui"},
                 },
             }
         )
 
-        # Example code execution block attached to the message
-        await emit(
-            {
-                "type": "source",
-                "data": {
-                    "type": "code_execution",
-                    "id": "calc",
-                    "name": "2 + 2",
-                    "code": "print(2 + 2)",
-                    "language": "python",
-                    "result": {"output": "4"},
-                },
-            }
-        )
-        await emit(
-            {
-                "type": "status",
-                "data": {
-                    "description": "✅ all done!",
-                    "done": True,
-                    "style": "success",
-                },
-            }
-        )
+        if not await confirm("Replace the final message and finish demo?"):
+            await run_js("document.getElementById('demo-banner')?.remove();")
+            return "Demo cancelled."
 
-        await emit(
-            {
-                "type": "notification",
-                "data": {"type": "success", "content": "Demo finished"},
-            }
-        )
-
-        if __event_call__:
-            await __event_call__(
-                {
-                    "type": "execute",
-                    "data": {
-                        "code": "document.getElementById('demo-banner')?.remove();"
-                    },
-                }
-            )
-
-        final_msg = f"🎉 Completed {total} units successfully."
+        final_msg = "🎉 Event demo finished successfully."
         await emit({"type": "replace", "data": {"content": final_msg}})
+
+        await emit({"type": "notification", "data": {"type": "success", "content": "Demo finished"}})
+        await run_js("document.getElementById('demo-banner')?.remove();")
+
         return final_msg


### PR DESCRIPTION
## Summary
- rewrite `event_emitter_example.py` as a concise event demo
- insert confirmations between each step and render HTML correctly

## Testing
- `nox -s lint tests`
