### PR TITLE
Disable tests but keep deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  pull_request:
+  # Temporarily disabled automatic triggers
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/openwebui_devtoolkit/**.py'    # run when a plugin changes
       - 'scripts/publish_to_webui.py'
+  workflow_dispatch:
 
 jobs:
 # ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- restore deploy workflow push trigger so extensions still publish
- CI workflow remains manual so tests won't run automatically

## Testing
- `nox -s lint tests`
