### PR TITLE
Install open-webui for dev extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ pip install -e '.[dev]'
 nox -s lint tests
 ```
 
+Installing the optional `dev` extras installs the Open WebUI package from the
+`external/open-webui` submodule so pipelines can import `open_webui` directly.
+
 `nox` reuses the current Python environment and sets up `PYTHONPATH` so tests run
 quickly. `pytest` executes with coverage enabled. Pre-commit hooks run the same
 checks so you get fast feedback before committing. Fixtures under `tests/` stub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dev = [
   "pytest",
   "pytest-cov",
   "pre-commit",
-  "nox"
+  "nox",
+  { path = "external/open-webui", develop = true }
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- include the open-webui submodule as an editable dependency for `dev`
- document that `pip install -e '.[dev]'` brings in open-webui

## Testing
- `nox -s lint tests`