### PR TITLE
Add scheduled sync for open-webui

### DIFF
--- a/.github/workflows/update-open-webui.yml
+++ b/.github/workflows/update-open-webui.yml
@@ -1,0 +1,25 @@
+name: Update Open WebUI
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clone upstream repository
+        run: |
+          rm -rf open-webui
+          git clone https://github.com/open-webui/open-webui.git open-webui
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'chore: update open-webui'
+          title: 'chore: update open-webui'
+          body: Automated update of the open-webui folder.
+          branch: update-open-webui

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,10 @@ instance.
 ---
 
 ## Upstream reference (read-only)
-Open WebUI source is included as a shallow submodule in `external/open-webui/`.
-**Codex:** use it for reference only—do **not** edit or commit changes
-inside that path.
+Open WebUI source is available in the `open-webui/` folder. A scheduled
+workflow refreshes this directory from the upstream repository. **Codex:**
+use it for reference only—do **not** edit or commit changes inside that
+path.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ nox -s lint tests
 ```
 
 Installing the optional `dev` extras installs the Open WebUI package from the
-`external/open-webui` submodule so pipelines can import `open_webui` directly.
+`open-webui` directory so pipelines can import `open_webui` directly. A
+scheduled workflow keeps this folder synced with the upstream repository.
 
 `nox` reuses the current Python environment and sets up `PYTHONPATH` so tests run
 quickly. `pytest` executes with coverage enabled. Pre-commit hooks run the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ src = ["src", "tests", "scripts"]
 [tool.setuptools.packages.find]
 exclude = [
   "external*",
+  "open-webui*",
   "tests*"
 ]
 


### PR DESCRIPTION
## Summary
- sync open-webui weekly via workflow
- update contributor docs about new open-webui folder
- mention automated sync in README
- exclude cloned repo from builds

## Testing
- `nox -s lint tests`