### PR TITLE
Update workflow path for OpenWebUI snapshot

### DIFF
--- a/.github/workflows/update-open-webui.yml
+++ b/.github/workflows/update-open-webui.yml
@@ -18,12 +18,12 @@ jobs:
     - uses: actions/checkout@v4
 
     # 2 ▸ snapshot upstream
-    - name: Copy upstream OpenWebUI
+    - name: Clone upstream OpenWebUI
       run: |
         set -euo pipefail
-        rm -rf open-webui
-        git clone --depth 1 https://github.com/open-webui/open-webui.git open-webui
-        rm -rf open-webui/.git
+        rm -rf external/open-webui
+        git clone --depth 1 https://github.com/open-webui/open-webui.git external/open-webui
+        rm -rf external/open-webui/.git   # remove the .git directory for clarity
 
     # 3 ▸ commit & push if anything changed
     - name: Commit & push branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,9 @@ nox -s lint tests
 `nox` uses the current Python environment, adds `src` to `PYTHONPATH` and
 executes `ruff` followed by `pytest`. Fixtures in `tests/conftest.py` stub out
 `open_webui` so tests stay fast and isolated.
+
+## Inspecting Embedded External Source Code
+When detailed understanding, debugging, or reverse-engineering of the external OpenWebUI source code is required, directly inspect the embedded source code located at:
+external/open-webui/
+Refer to [External Repositories Guide](external/EXTERNAL_REPOS_GUIDE.md) for more details about this embedded repository.
+This resource provides crucial context for how external components function and interact with our custom extensions (functions and tools).

--- a/external/EXTERNAL_REPOS_GUIDE.md
+++ b/external/EXTERNAL_REPOS_GUIDE.md
@@ -1,0 +1,19 @@
+# External Repositories Guide
+
+This directory (`external/`) contains external source code repositories directly embedded into our project for easy reference and analysis.
+
+## Current External Repositories:
+- **OpenWebUI Source**
+    Path: `external/open-webui/`
+    URL: [https://github.com/open-webui/open-webui](https://github.com/open-webui/open-webui)
+
+### Purpose:
+The OpenWebUI repository is embedded here to allow easy navigation, analysis, and reverse-engineering of its internal source code. It provides direct reference and context for our custom functions and tools.
+
+### How to Update:
+A GitHub workflow (`.github/workflows/update-open-webui.yml`) is configured to regularly synchronize this embedded repository with the upstream main branch.
+
+### Usage by AI Agents:
+AI agents should explore the embedded OpenWebUI source directly in:
+external/open-webui/
+for deeper understanding, detailed inspection, or reverse-engineering tasks.


### PR DESCRIPTION
## Summary
- clone OpenWebUI into `external/open-webui` via workflow
- document embedded source under `external/`
- guide agents to inspect embedded source code

## Testing
- `nox -s lint tests`