### PR TITLE
Update OpenWebUI snapshot path

### DIFF
--- a/.github/workflows/update-open-webui.yml
+++ b/.github/workflows/update-open-webui.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Copy upstream OpenWebUI
       run: |
         set -euo pipefail
-        rm -rf open-webui
-        git clone --depth 1 https://github.com/open-webui/open-webui.git open-webui
-        rm -rf open-webui/.git
+        rm -rf external/open-webui
+        git clone --depth 1 https://github.com/open-webui/open-webui.git external/open-webui
+        rm -rf external/open-webui/.git
 
     # 3 ▸ commit & push if anything changed
     - name: Commit & push branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ running WebUI instance.
 ---
 
 ## Upstream reference (read-only)
-If present, the `open-webui/` folder mirrors the upstream project. Use it for
+If present, the `external/open-webui/` folder mirrors the upstream project. Use it for
 reference only—do **not** edit or commit changes inside that path.
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ nox -s lint tests
 ```
 
 Installing the optional `dev` extras installs the Open WebUI package from the
-`open-webui` directory so pipelines can import `open_webui` directly. A
+`external/open-webui` directory so pipelines can import `open_webui` directly. A
 scheduled workflow keeps this folder synced with the upstream repository.
 
 `nox` reuses the current Python environment and sets up `PYTHONPATH` so tests run

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,9 @@
+# External Reference
+
+Snapshots of external projects live in this folder.  The `open-webui` subdirectory
+contains a read-only copy of the upstream [Open WebUI](https://github.com/open-webui/open-webui)
+repository.  A scheduled workflow updates the snapshot automatically so tools and
+pipes can depend on the real codebase during development.
+
+Browse `external/open-webui/` if you need to inspect how Open WebUI works, but do
+not modify anything inside that path.


### PR DESCRIPTION
## Summary
- clone upstream OpenWebUI into `external/open-webui/`
- mention new path in README
- adjust contributor notes to reference `external/open-webui/`
- add README under `external/`

## Testing
- `nox -s lint tests`