### PR TITLE
Improve tool server docs

### DIFF
--- a/external/TOOLS_GUIDE.md
+++ b/external/TOOLS_GUIDE.md
@@ -101,3 +101,14 @@ for path, methods in openapi_spec.get("paths", {}).items():
 
 These lines continue by resolving request body schemas and appending the final
 tool object to the list returned by the function.
+
+### Configuration and caching
+
+Connections to tool servers are defined in the `TOOL_SERVER_CONNECTIONS`
+environment variable. `config.py` loads this JSON list at startup and stores it
+as a persistent setting【F:external/open-webui/backend/open_webui/config.py†L884-L897】.
+When the `/tools` endpoint is first called the router fetches each server's
+OpenAPI spec via `get_tool_servers_data` and caches the result in
+`app.state.TOOL_SERVERS`【F:external/open-webui/backend/open_webui/routers/tools.py†L38-L45】.
+The returned list of tools includes these remote operations by enumerating each
+server with an index before merging the specs with local tools【F:external/open-webui/backend/open_webui/routers/tools.py†L48-L71】.

--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -90,6 +90,9 @@ class Pipe:
 ```
 
 `get_tools()` builds this mapping and handles valve hydration for tools. See `tools/README.md` for more details.
+Remote entries starting with `server:` are generated from OpenAPI specs and
+behave like local tools. They are configured through
+`TOOL_SERVER_CONNECTIONS` and cached in `app.state.TOOL_SERVERS`.
 
 ## Pipe lifecycle
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -111,10 +111,18 @@ async def pipe(self, body, __tools__):
 Remote **tool servers** are also supported. When a tool id starts with
 `server:` the loader fetches an OpenAPI document and converts each
 `operationId` into a tool definition using `convert_openapi_to_tool_payload`.
-Server entries are configured under `TOOL_SERVER_CONNECTIONS` and can use a
-Bearer or session token for authentication. Calls are then proxied via
-`execute_tool_server` so the remote HTTP API behaves like a local tool
-【F:external/TOOLS_GUIDE.md†L53-L79】【F:external/TOOLS_GUIDE.md†L80-L103】.
+Server entries are configured under the `TOOL_SERVER_CONNECTIONS` setting and
+may use a Bearer or session token for authentication. The specification is
+downloaded once with `get_tool_servers_data` and cached in
+`request.app.state.TOOL_SERVERS` so that subsequent requests do not hit the
+remote server again【F:external/open-webui/backend/open_webui/routers/tools.py†L38-L45】.
+Each OpenAPI operation is exposed as a tool and returned alongside local tools
+when calling `GET /tools`【F:external/open-webui/backend/open_webui/routers/tools.py†L48-L71】.
+Calls are proxied via `execute_tool_server` so the HTTP API behaves like a local
+tool【F:external/TOOLS_GUIDE.md†L53-L79】【F:external/TOOLS_GUIDE.md†L80-L103】.
+
+See [external/TOOLS_GUIDE.md](../external/TOOLS_GUIDE.md) for a deeper look at
+the request flow and schema conversion logic.
 
 ## Events and callbacks
 


### PR DESCRIPTION
## Summary
- document remote tool server caching and config
- reference tool servers from pipe docs

## Testing
- `nox -s lint tests`