### PR TITLE
Use yield for streaming

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -200,7 +200,7 @@ async def test_pipe_stream_loop(dummy_chat):
     with patch.object(pipeline, "stream_responses", fake_stream), patch.object(
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
-        await pipe.pipe(
+        gen = pipe.pipe(
             {},
             {},
             None,
@@ -210,15 +210,12 @@ async def test_pipe_stream_loop(dummy_chat):
             {"chat_id": "chat1", "message_id": "m1", "function_calling": "native"},
             {},
         )
+        tokens = []
+        async for chunk in gen:
+            tokens.append(chunk)
     await pipe.on_shutdown()
 
-    assert [e["data"] for e in emitted if e["type"] == "message"] == [
-        {"content": "<think>"},
-        {"content": "t"},
-        {"content": "\n\n---\n\n"},
-        {"content": "</think>\n"},
-        {"content": "hi"},
-    ]
+    assert tokens == ["<think>", "t", "\n\n---\n\n", "</think>\n", "hi"]
     assert [e["data"] for e in emitted if e["type"] == "chat:completion"] == [
         {"usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3, "loops": 1}},
         {"done": True},

--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -180,11 +180,13 @@ adds a database write on every call. |
 | `replace`       | Replaces the stored message content entirely. Used to rewrite
 or fix messages. |
 | `chat:completion` | Sends data to the UI only. The DB is not touched until the
-middleware finishes and emits a final `done` event. |
+middleware finishes and emits a final `done` event. Use this when emitting
+tokens via `__event_emitter__`. |
 
-When speed matters you can `yield` text directly from your generator instead of
-sending many `message` events. `yield` skips the extra database updates while the
-UI still receives tokens in real time. Combine approaches as needed:
+When maximum speed matters you can `yield` text directly from your generator
+instead of sending many `message` or `chat:completion` events. `yield` skips the
+extra database updates and event overhead while the UI still receives tokens in
+real time. Combine approaches as needed:
 
 ```python
 async def pipe(self, body, __event_emitter__):


### PR DESCRIPTION
## Summary
- switch OpenAI responses pipeline to yield tokens instead of emitting `chat:completion` events
- document yield-vs-event streaming trade-offs
- adjust pipeline tests for yielded tokens

## Testing
- `nox -s lint tests`