### PR TITLE
Clarify custom field persistence

### DIFF
--- a/docs/chat_persistence_notes.md
+++ b/docs/chat_persistence_notes.md
@@ -13,6 +13,9 @@ This document summarizes how chat messages are stored in the upstream Open WebUI
 - Located in `backend/open_webui/models/chats.py`.
 - Merges the provided dictionary into the existing message entry or creates a new one.
 - There is no schema validation – arbitrary keys are stored as given.
+- Custom fields added to a message dictionary will therefore persist
+  in the database. They may be ignored by the default UI unless
+  additional code knows how to handle them.
 
 ## Middleware serialization
 - `backend/open_webui/utils/middleware.py` builds messages from `content_blocks`.

--- a/external/CHAT_GUIDE.md
+++ b/external/CHAT_GUIDE.md
@@ -195,6 +195,9 @@ context and return the resulting dictionary.
 
 `backend/open_webui/models/chats.py` stores each conversation in a JSON field. The `history` object maps message ids to dictionaries that include `role` and `content`.
 `upsert_message_to_chat_by_id_and_message_id(id, message_id, data)` merges `data` into the existing message. Unknown keys are kept as-is because the table does not enforce a schema.
+This means custom fields placed in each message dictionary are persisted in the
+database. The default UI only understands a small subset of keys so additional
+logic is required to display or act on any extra data.
 
 During streaming the middleware repeatedly calls this helper with partial events. Once the model finishes it writes the final content string, which replaces the previous text but preserves earlier metadata.
 


### PR DESCRIPTION
## Summary
- clarify in the chat persistence docs that arbitrary keys persist in the DB

## Testing
- `nox -s lint tests`