### PR TITLE
Fix tool call persistence

### DIFF
--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -1090,5 +1090,16 @@ def parse_responses_sse(event_type: str | None, data: str) -> ResponsesEvent:
 
 def store_partial_message(chat_id: str, message_id: str, content: str) -> None:
     """Persist a partial streamed message for future inspection."""
-    # TODO: implement persistence logic
-    _ = (chat_id, message_id, content)
+    try:
+        Chats.upsert_message_to_chat_by_id_and_message_id(
+            chat_id,
+            message_id,
+            {"content": [{"type": "output_text", "text": content}]},
+        )
+        logger.debug(
+            "Stored partial message for chat=%s message=%s",
+            chat_id,
+            message_id,
+        )
+    except Exception as ex:  # pragma: no cover - debug only
+        logger.debug("Failed to store partial message: %s", ex)


### PR DESCRIPTION
## Summary
- implement store_partial_message to persist partial outputs
- add debug logging for failures

## Testing
- `nox -s lint tests`