### PR TITLE
Refine OpenAI responses pipe naming

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -100,7 +100,7 @@ def test_build_params_includes_reasoning(dummy_chat):
     pipe = pipeline.Pipe()
     pipe.valves.REASON_EFFORT = "high"
     pipe.valves.REASON_SUMMARY = "concise"
-    body = {"model": "openai_responses_api_pipeline.o3", "max_tokens": 50, "temperature": 0.4, "top_p": 0.9}
+    body = {"model": "openai_responses.o3", "max_tokens": 50, "temperature": 0.4, "top_p": 0.9}
     params = pipe._build_params(body, "ins", [{"type": "function"}], "me@example.com")
     assert params["tool_choice"] == "auto"
     assert params["max_output_tokens"] == 50
@@ -114,7 +114,7 @@ def test_build_params_drops_reasoning_for_base_model(dummy_chat):
     pipeline = _reload_pipeline()
     pipe = pipeline.Pipe()
     pipe.valves.REASON_EFFORT = "high"
-    body = {"model": "openai_responses_api_pipeline.gpt-4.1"}
+    body = {"model": "openai_responses.gpt-4.1"}
     params = pipe._build_params(body, "ins", [], None)
     assert "reasoning" not in params
 

--- a/docs/chat_persistence_notes.md
+++ b/docs/chat_persistence_notes.md
@@ -70,7 +70,7 @@ so progress and results can be displayed in the WebUI. Example output:
 - Final message writes from the middleware overwrite `content` but keep previously stored fields due to the merge logic.
 
 ### Custom tool metadata
-The `openai_responses_api_pipeline` stores `function_call` and
+The `openai_responses` pipeline stores `function_call` and
 `function_call_output` events using two arrays:
 
 ```json

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -1,6 +1,6 @@
 """
 title: OpenAI Responses API Pipeline
-id: openai_responses_api_pipeline
+id: openai_responses
 author: Justin Kropp
 author_url: https://github.com/jrkropp
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
@@ -198,12 +198,12 @@ class Pipe:
     def __init__(self) -> None:
         """Initialize the pipeline and logging."""
         self.valves = self.Valves()
-        self.name = "OpenAI Responses"
+        self.log_name = "OpenAI Responses"
         self._client: httpx.AsyncClient | None = None
         self._transport: httpx.AsyncHTTPTransport | None = None
         self._client_lock = asyncio.Lock()
 
-        self.log = logging.getLogger(self.name)
+        self.log = logging.getLogger(self.log_name)
         self.log.propagate = False
         handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(logging.Formatter("%(emo)s %(levelname)-8s | %(name)-20s:%(lineno)-4d — %(message)s"))
@@ -274,7 +274,7 @@ class Pipe:
 
         self.log.info(
             'CHAT_MSG pipe="%s" model=%s user=%s chat=%s message=%s',
-            self.name,
+            self.log_name,
             body.get("model", self.valves.MODEL_ID),
             __user__.get("email", "anon"),
             __metadata__["chat_id"],


### PR DESCRIPTION
## Summary
- shorten pipe `id` to `openai_responses`
- avoid prefixing model names by removing `name` attribute
- update unit tests and docs for new ID

## Testing
- `nox -s lint tests`