### PR TITLE
Auto enable native function calling

### DIFF
--- a/.tests/conftest.py
+++ b/.tests/conftest.py
@@ -40,6 +40,22 @@ def dummy_chat(monkeypatch):
         "httpx": types.ModuleType("httpx"),
     }
 
+    models_mod = types.ModuleType("open_webui.models.models")
+
+    class ModelForm:
+        def __init__(self, **data):
+            for k, v in data.items():
+                setattr(self, k, v)
+
+    models_mod.ModelForm = ModelForm
+    models_mod.ModelParams = ModelForm
+    models_mod.Models = types.SimpleNamespace(
+        get_model_by_id=lambda _id: None,
+        update_model_by_id=lambda _id, form: None,
+    )
+
+    modules["open_webui.models.models"] = models_mod
+
     modules["open_webui.utils.misc"].deep_update = lambda d, u: {**d, **u}
     def _get_msg_list(msgs, mid):
         out = []

--- a/external/MODELS_GUIDE.md
+++ b/external/MODELS_GUIDE.md
@@ -148,3 +148,25 @@ Validates that a user can see the given model.  Arena models honour the
 function consults `Models.get_model_by_id` and verifies ownership or explicit
 permissions via `has_access`.
 
+### Updating models
+
+Use `Models.update_model_by_id` to modify a model's metadata or parameters.
+Construct a `ModelForm` with the desired fields and pass it along with the
+model id. Only the provided attributes are changed:
+
+```python
+model = Models.get_model_by_id("gpt-4o")
+params = model.params.model_dump()
+params["function_calling"] = "native"
+form = ModelForm(
+    id=model.id,
+    name=model.name,
+    base_model_id=model.base_model_id,
+    meta=model.meta,
+    params=ModelParams(**params),
+    access_control=model.access_control,
+    is_active=model.is_active,
+)
+Models.update_model_by_id(model.id, form)
+```
+


### PR DESCRIPTION
## Summary
- automatically update the model to use native function calling when tools are detected
- stub out `Models` in tests
- document how to update models with `Models.update_model_by_id`
- log the automatic update instead of emitting a chat message

## Testing
- `nox -s lint tests`
