### PR TITLE
Optimize SSE and cleanup helpers

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -146,15 +146,6 @@ def test_update_usage_accumulates(dummy_chat):
         "loops": 2,
     }
 
-
-def test_to_obj_to_dict_roundtrip(dummy_chat):
-    pipeline = _reload_pipeline()
-    data = {"a": {"b": [1, {"c": 2}]}, "d": (3, 4)}
-    obj = pipeline.to_obj(data)
-    roundtrip = pipeline.to_dict(obj)
-    assert roundtrip == data
-
-
 def test_parse_responses_sse_handles_extra_fields(dummy_chat):
     pipeline = _reload_pipeline()
     raw = json.dumps({"annotation": {"title": "t"}, "delta": "x"})

--- a/docs/openai_responses_api_pipeline_plan.md
+++ b/docs/openai_responses_api_pipeline_plan.md
@@ -122,7 +122,9 @@ Use asyncio.gather for tool calls if multiple calls come in at once.
 Initial SSE parsing relied on ``json.loads`` with ``object_hook``.  The
 implementation now parses only the top-level keys and converts nested
 structures on demand.  Annotation regexes are precompiled and debug formatting
-is wrapped in ``DEBUG`` checks to further cut CPU cost.
+is wrapped in ``DEBUG`` checks to further cut CPU cost.  Unused
+``to_obj``/``to_dict`` helpers were dropped and usage aggregation no longer
+recursively copies objects, trimming a bit more CPU work.
 
 ⸻
 


### PR DESCRIPTION
## Summary
- streamline streaming performance docs
- bump OpenAI responses pipeline version
- remove unused to_obj/to_dict helpers and simplify usage aggregation
- tweak SSE parsing and update tests

## Testing
- `nox -s lint tests`