### PR TITLE
Update pipeline for native tool toggling

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -99,9 +99,14 @@ def test_apply_user_overrides_sets_log_level(dummy_chat):
 def test_build_params_includes_reasoning(dummy_chat):
     pipeline = _reload_pipeline()
     pipe = pipeline.Pipe()
-    pipe.valves.REASON_EFFORT = "high"
     pipe.valves.REASON_SUMMARY = "concise"
-    body = {"model": "openai_responses.o3", "max_tokens": 50, "temperature": 0.4, "top_p": 0.9}
+    body = {
+        "model": "openai_responses.o3",
+        "max_tokens": 50,
+        "temperature": 0.4,
+        "top_p": 0.9,
+        "reasoning_effort": "high",
+    }
     params = pipeline.assemble_responses_payload(
         pipe.valves,
         "chat1",
@@ -121,8 +126,7 @@ def test_build_params_includes_reasoning(dummy_chat):
 def test_build_params_drops_reasoning_for_base_model(dummy_chat):
     pipeline = _reload_pipeline()
     pipe = pipeline.Pipe()
-    pipe.valves.REASON_EFFORT = "high"
-    body = {"model": "openai_responses.gpt-4.1"}
+    body = {"model": "openai_responses.gpt-4.1", "reasoning_effort": "high"}
     params = pipeline.assemble_responses_payload(
         pipe.valves,
         "chat1",


### PR DESCRIPTION
## Summary
- add valve to control native tool calling
- skip enabling native tool calling for chatgpt-4o-latest and codex-mini-latest
- take reasoning effort from request body instead of valve
- update tests for new behaviour

## Testing
- `nox -s lint tests`