### PR TITLE
Add smooth streaming buffering

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -283,6 +283,45 @@ async def test_pipe_stream_loop(dummy_chat):
 
 
 @pytest.mark.asyncio
+async def test_smooth_streaming_buffers_output(dummy_chat):
+    pipeline = _reload_pipeline()
+    pipe = pipeline.Pipe()
+    pipe.valves.SMOOTH_STREAM_MS = 15
+
+    events = [
+        types.SimpleNamespace(type="response.output_text.delta", delta="a"),
+        types.SimpleNamespace(type="response.output_text.delta", delta="b"),
+        types.SimpleNamespace(type="response.output_text.delta", delta="c"),
+        types.SimpleNamespace(type="response.output_text.done", text="abc"),
+        types.SimpleNamespace(type="response.completed", response=types.SimpleNamespace(usage={})),
+    ]
+
+    async def fake_stream(*_a, **_kw):
+        for e in events:
+            yield e
+
+    pc_vals = iter([0.0, 0.005, 0.010, 0.020, 0.025, 0.030])
+
+    with patch.object(pipeline, "stream_responses", fake_stream), patch.object(
+        pipe, "get_http_client", AsyncMock(return_value=object())
+    ), patch("openai_responses_api_pipeline.time.perf_counter", side_effect=lambda: next(pc_vals)):
+        gen = pipe.pipe(
+            {},
+            {},
+            None,
+            AsyncMock(),
+            AsyncMock(),
+            [],
+            {"chat_id": "chat1", "message_id": "m1", "function_calling": "native"},
+            {},
+        )
+        tokens = [chunk async for chunk in gen]
+    await pipe.on_shutdown()
+
+    assert tokens == ["abc"]
+
+
+@pytest.mark.asyncio
 async def test_pipe_deletes_response(dummy_chat):
     pipeline = _reload_pipeline()
     pipe = pipeline.Pipe()

--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -23,3 +23,7 @@ building the request payload, streaming Server-Sent Events (SSE), and executing
 tool calls.  See `openai_responses_api_pipeline.py` for async helpers such as
 `assemble_responses_payload`, `assemble_responses_input`, `stream_responses`,
 and `execute_responses_tool_calls`.
+
+Version 1.6.17 introduces an optional **smooth streaming** valve
+(`SMOOTH_STREAM_MS`) to buffer SSE token deltas and emit them at a
+fixed interval. Set the value to `0` to disable buffering.

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -4,7 +4,7 @@ id: openai_responses
 author: Justin Kropp
 author_url: https://github.com/jrkropp
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 1.6.16
+version: 1.6.17
 license: MIT
 requirements: httpx
 
@@ -34,6 +34,7 @@ requirements: httpx
 ------------------------------------------------------------------------------
 🛠 CHANGE LOG
 ------------------------------------------------------------------------------
+• 1.6.17: Optional smooth-stream buffer for SSE tokens.
 • 1.6.16: Valve to control persisting tool results in chat history.
 • 1.6.15: Added valve to toggle native tool calling; skips unsupported models; `reasoning_effort` now read directly from request body.
 • 1.6.11: Disabled HTTP/2 to prevent stream stalls; optimized connection pooling.
@@ -161,6 +162,13 @@ class Pipe:
             default=True,
             description="Whether tool calls can be parallelized. Defaults to True if not set.",
         )  # Read more: https://platform.openai.com/docs/api-reference/responses/create#responses-create-parallel_tool_calls
+
+        SMOOTH_STREAM_MS: int = Field(
+            default=0,
+            description=(
+                "Buffer streaming deltas and emit them every N milliseconds. 0 disables buffering."
+            ),
+        )
 
         # TODO Need to rename as it's not truely max tool calls.  It's max tool loops.  It can call an unlimited number of tools within a single loop.
         MAX_TOOL_CALLS: int = Field(
@@ -332,6 +340,11 @@ class Pipe:
                 pending_calls: list[SimpleNamespace] = []
                 if self.log.isEnabledFor(logging.DEBUG):
                     self.log.debug("response_stream created for loop #%d", loop_count)
+                smooth_ms = self.valves.SMOOTH_STREAM_MS
+                buf: list[str] = []
+                last_emit = time.perf_counter()
+                interval = smooth_ms / 1000 if smooth_ms else 0
+
                 async for event in stream_responses(
                     client, self.valves.BASE_URL, self.valves.API_KEY, request_params
                 ):
@@ -345,6 +358,10 @@ class Pipe:
                         last_response_id = event.response.id
                         continue
                     if et in {"response.done", "response.failed", "response.incomplete", "error"}:
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         self.log.error("Stream ended with event: %s", et)
                         break
                     if et == "response.reasoning_summary_part.added":
@@ -353,9 +370,21 @@ class Pipe:
                             yield "<think>"
                         continue
                     if et == "response.reasoning_summary_text.delta":
-                        yield event.delta
+                        if smooth_ms:
+                            buf.append(event.delta)
+                            now = time.perf_counter()
+                            if now - last_emit >= interval:
+                                yield "".join(buf)
+                                buf.clear()
+                                last_emit = now
+                        else:
+                            yield event.delta
                         continue
                     if et == "response.reasoning_summary_text.done":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         yield "\n\n---\n\n"
                         continue
                     if et == "response.content_part.added":
@@ -364,12 +393,28 @@ class Pipe:
                             yield "</think>\n"
                         continue
                     if et == "response.output_text.delta":
-                        yield event.delta
+                        if smooth_ms:
+                            buf.append(event.delta)
+                            now = time.perf_counter()
+                            if now - last_emit >= interval:
+                                yield "".join(buf)
+                                buf.clear()
+                                last_emit = now
+                        else:
+                            yield event.delta
                         continue
                     if et == "response.output_text.done":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         # This delta marks the end of the current output block.
                         continue
                     if et == "response.output_item.added":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         item = getattr(event, "item", None)
                         if getattr(item, "type", None) == "function_call":
                             await self._emit_status(
@@ -381,6 +426,10 @@ class Pipe:
                             )
                         continue
                     if et == "response.output_item.done":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         item = getattr(event, "item", None)
                         if getattr(item, "type", None) == "function_call":
                             pending_calls.append(item)
@@ -393,6 +442,10 @@ class Pipe:
                             )
                         continue
                     if et == "response.output_text.annotation.added":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         raw = str(getattr(event, "annotation", ""))
                         title_m = ANNOT_TITLE_RE.search(raw)
                         url_m = ANNOT_URL_RE.search(raw)
@@ -402,6 +455,10 @@ class Pipe:
                         await __event_emitter__({"type": "citation", "data": {"document": [title], "metadata": [{"date_accessed": datetime.now().isoformat(), "source": title}], "source": {"name": url, "url": url}}})
                         continue
                     if et == "response.completed":
+                        if smooth_ms and buf:
+                            yield "".join(buf)
+                            buf.clear()
+                            last_emit = time.perf_counter()
                         if event.response.usage:
                             self._update_usage(
                                 usage_total, event.response.usage, loop_count


### PR DESCRIPTION
## Summary
- add new `SMOOTH_STREAM_MS` valve
- buffer SSE token deltas when enabled
- document the feature
- add unit test skeleton for smooth streaming

## Testing
- `nox -s lint`
- `nox -s tests`