### PR TITLE
Add prompt enrichment valves

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -78,6 +78,28 @@ def test_extract_instructions(dummy_chat):
     assert pipeline.Pipe._extract_instructions(body) == "two"
 
 
+def test_instruction_suffix_helpers(dummy_chat):
+    pipeline = _reload_pipeline()
+    pipe = pipeline.Pipe()
+
+    date_line = pipe._get_current_date_suffix()
+    assert "Today's date:" in date_line
+
+    req = types.SimpleNamespace(
+        headers={
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"Windows"',
+            "user-agent": "Mozilla/5.0 Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0",
+        },
+        client=types.SimpleNamespace(host="207.194.4.18", port=0),
+    )
+    ctx = pipe._get_user_context_suffix(
+        {"name": "Justin", "email": "me@example.com"}, req
+    )
+    assert "user_info: Justin <me@example.com>" in ctx
+    assert "device_info:" in ctx
+
+
 def test_apply_user_overrides_sets_log_level(dummy_chat):
     pipeline = _reload_pipeline()
     pipe = pipeline.Pipe()
@@ -752,4 +774,10 @@ async def test_tools_removed_for_unsupported_model(dummy_chat):
 
     assert "tools" not in captured_params[0]
     assert "tool_choice" not in captured_params[0]
+
+
+def test_simplify_user_agent_helper(dummy_chat):
+    pipeline = _reload_pipeline()
+    ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136.0.0.0 Safari/537.36"
+    assert pipeline.simplify_user_agent(ua) == "Chrome 136"
 

--- a/docs/instruction_injection_valves.md
+++ b/docs/instruction_injection_valves.md
@@ -1,0 +1,20 @@
+# Instruction Injection Valves
+
+The `openai_responses` pipeline supports two optional valves that enrich the system prompt.
+
+* **INJECT_CURRENT_DATE** – when set to `True` the current date is appended at the end of the system instructions. Example output:
+
+```
+[existing system prompt]
+
+Today's date: Thursday, May 21, 2025
+```
+
+* **INJECT_USER_INFO** – when enabled the user's name and email are appended. If request data is available, a short `device_info` line is also added summarising the client platform and browser. This information is marked as context only.
+
+```
+user_info: Justin Kropp <jkropp@glcsolutions.ca>
+device_info: Desktop | Windows | IP: 207.194.4.18 | Browser: Edge 136
+
+Note: `user_info` and `device_info` provided solely for AI contextual enrichment.
+```

--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -23,3 +23,6 @@ building the request payload, streaming Server-Sent Events (SSE), and executing
 tool calls.  See `openai_responses_api_pipeline.py` for async helpers such as
 `assemble_responses_payload`, `assemble_responses_input`, `stream_responses`,
 and `execute_responses_tool_calls`.
+
+Additional valves for injecting the current date and user context are documented in
+`docs/instruction_injection_valves.md`.


### PR DESCRIPTION
## Summary
- add valves `INJECT_CURRENT_DATE` and `INJECT_USER_INFO`
- enrich system prompt with date and user/device context when enabled
- parse browser string via `simplify_user_agent`
- document new valves and reference in README
- test enrichment helpers
- refactor instruction enrichment helpers

## Testing
- `nox -s lint tests`