### PR TITLE
Add IP location caching

### DIFF
--- a/docs/instruction_injection_valves.md
+++ b/docs/instruction_injection_valves.md
@@ -10,11 +10,15 @@ The `openai_responses` pipeline supports two optional valves that enrich the sys
 Today's date: Thursday, May 21, 2025
 ```
 
-* **INJECT_USER_INFO** – when enabled the user's name and email are appended. If request data is available, a short `device_info` line is also added summarising the client platform and browser. This information is marked as context only.
+* **INJECT_USER_INFO** – when enabled the user's name and email are appended. If
+  request data is available, a short `device_info` line is also added summarising
+  the client platform, browser and IP address. The IP is lazily resolved using
+  [ip-api.com](http://ip-api.com) and cached, so location details appear on
+  subsequent requests. This information is marked as context only.
 
 ```
 user_info: Justin Kropp <jkropp@glcsolutions.ca>
-device_info: Desktop | Windows | IP: 207.194.4.18 | Browser: Edge 136
+device_info: Desktop | Windows | IP: 207.194.4.18 - Waterloo, Ontario, Canada | Browser: Edge 136
 
 Note: `user_info` and `device_info` provided solely for AI contextual enrichment.
 ```


### PR DESCRIPTION
## Summary
- fetch IP info in background for user context
- cache lookup results to avoid repeat requests
- document IP lookup caching in injection valves guide
- test IP location caching logic

## Testing
- `nox -s lint tests`