### PR TITLE
Improve IP lookup logging & ISP info

### DIFF
--- a/docs/instruction_injection_valves.md
+++ b/docs/instruction_injection_valves.md
@@ -13,12 +13,12 @@ Today's date: Thursday, May 21, 2025
 * **INJECT_USER_INFO** – when enabled the user's name and email are appended. If
   request data is available, a short `device_info` line is also added summarising
   the client platform, browser and IP address. The IP is lazily resolved using
-  [ip-api.com](http://ip-api.com) and cached, so location details appear on
-  subsequent requests. This information is marked as context only.
+  [ip-api.com](http://ip-api.com) and cached, so the approximate location and ISP
+  appear on subsequent requests. This information is marked as context only.
 
 ```
 user_info: Justin Kropp <jkropp@glcsolutions.ca>
-device_info: Desktop | Windows | IP: 207.194.4.18 - Waterloo, Ontario, Canada | Browser: Edge 136
+device_info: Desktop | Windows | IP: 207.194.4.18 - Waterloo, Ontario, Canada (Bell Canada) | Browser: Edge 136
 
 Note: `user_info` and `device_info` provided solely for AI contextual enrichment.
 ```


### PR DESCRIPTION
## Summary
- update instruction injection docs with ISP example
- cache IP lookups with ISP data and add debug logs

## Testing
- `nox -s lint tests`