### PR TITLE
Add granular user info injection options

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -94,7 +94,7 @@ def test_instruction_suffix_helpers(dummy_chat):
         client=types.SimpleNamespace(host="207.194.4.18", port=0),
     )
     ctx = pipe._get_user_context_suffix(
-        {"name": "Justin", "email": "me@example.com"}, req
+        {"name": "Justin", "email": "me@example.com"}, req, include_ip=True
     )
     assert "user_info: Justin <me@example.com>" in ctx
     assert "device_info:" in ctx
@@ -135,11 +135,15 @@ async def test_ip_lookup_cached(dummy_chat):
         client=types.SimpleNamespace(host="207.194.4.18", port=0),
     )
 
-    first = pipe._get_user_context_suffix({"name": "Justin", "email": "me@example.com"}, req)
+    first = pipe._get_user_context_suffix(
+        {"name": "Justin", "email": "me@example.com"}, req, include_ip=True
+    )
     assert "Waterloo" not in first
     for task in list(pipe._ip_tasks.values()):
         await task
-    second = pipe._get_user_context_suffix({"name": "Justin", "email": "me@example.com"}, req)
+    second = pipe._get_user_context_suffix(
+        {"name": "Justin", "email": "me@example.com"}, req, include_ip=True
+    )
     assert "Waterloo" in second
     assert pipe._ip_cache.get("207.194.4.18")
 

--- a/docs/instruction_injection_valves.md
+++ b/docs/instruction_injection_valves.md
@@ -10,11 +10,15 @@ The `openai_responses` pipeline supports two optional valves that enrich the sys
 Today's date: Thursday, May 21, 2025
 ```
 
-* **INJECT_USER_INFO** – when enabled the user's name and email are appended. If
-  request data is available, a short `device_info` line is also added summarising
-  the client platform, browser and IP address. The IP is lazily resolved using
-  [ip-api.com](http://ip-api.com) and cached, so the approximate location and ISP
-  appear on subsequent requests. This information is marked as context only.
+* **INJECT_USER_INFO** – controls how much user context is appended. Options:
+  * `Disabled` – no information added (default).
+  * `Username and Email` – adds a `user_info` line with the user's name and email.
+  * `Username, Email and IP` – also adds a `device_info` line summarising the
+    client platform, browser and IP address. The IP is lazily resolved using
+    [ip-api.com](http://ip-api.com) and cached so the approximate location and ISP
+    appear on subsequent requests. This information is marked as context only.
+
+Example output when using `Username, Email and IP`:
 
 ```
 user_info: Justin Kropp <jkropp@glcsolutions.ca>


### PR DESCRIPTION
## Summary
- allow selecting how much user info to inject
- update docs for instruction injection valves
- adapt tests for new include_ip flag

## Testing
- `nox -s lint tests`