### PR TITLE
Fix emitter handling in web search filter

### DIFF
--- a/.tests/test_web_search_toggle_filter.py
+++ b/.tests/test_web_search_toggle_filter.py
@@ -1,6 +1,7 @@
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 import sys
+import asyncio
 import pytest
 
 
@@ -47,5 +48,19 @@ async def test_search_preview_for_other_models():
     out = await flt.inlet(body, __tools__=reg)
     assert out["model"] == "gpt-4o-search-preview"
     assert any(t.get("type") == "web_search" for t in reg.get("tools", []))
+
+
+def test_outlet_handles_missing_emitter():
+    mod = _load_filter()
+    flt = mod.Filter()
+    body = {
+        "model": "other",
+        "messages": [
+            {"role": "assistant", "content": "see https://ex.com/?utm_source=openai"}
+        ],
+    }
+
+    out = asyncio.run(flt.outlet(body, __event_emitter__=None))
+    assert out is body
 
 

--- a/functions/filters/web_search_toggle_filter.py
+++ b/functions/filters/web_search_toggle_filter.py
@@ -144,7 +144,10 @@ class Filter:
         return matches
 
     @staticmethod
-    async def _emit_citation(emitter: callable, url: str) -> None:
+    async def _emit_citation(emitter: callable | None, url: str) -> None:
+        if emitter is None:
+            return
+
         cleaned = url.replace("?utm_source=openai", "").replace("&utm_source=openai", "")
         await emitter(
             {
@@ -160,7 +163,10 @@ class Filter:
         )
 
     @staticmethod
-    async def _emit_status(emitter: callable, description: str, *, done: bool = False) -> None:
+    async def _emit_status(emitter: callable | None, description: str, *, done: bool = False) -> None:
+        if emitter is None:
+            return
+
         await emitter(
             {"type": "status", "data": {"description": description, "done": done, "hidden": False}}
         )


### PR DESCRIPTION
## Summary
- avoid errors when `__event_emitter__` is missing
- test missing-emitter case for `web_search_toggle_filter`

## Testing
- `nox -s lint tests`