### PR TITLE
Fix web search filter return path

### DIFF
--- a/.tests/test_web_search_toggle_filter.py
+++ b/.tests/test_web_search_toggle_filter.py
@@ -64,3 +64,12 @@ def test_outlet_handles_missing_emitter():
     assert out is body
 
 
+def test_outlet_returns_body_for_supported_model():
+    mod = _load_filter()
+    flt = mod.Filter()
+    body = {"model": "openai_responses.gpt-4o"}
+
+    out = asyncio.run(flt.outlet(body, __event_emitter__=None))
+    assert out is body
+
+

--- a/functions/filters/web_search_toggle_filter.py
+++ b/functions/filters/web_search_toggle_filter.py
@@ -135,12 +135,15 @@ class Filter:
                 msg = "Search not used — answer based on model's internal knowledge."
     
             await self._emit_status(__event_emitter__, msg, done=True)
-    
+
             return body
+
+        return body
 
     @staticmethod
     def _extract_urls(text: str) -> list[str]:
-        matches = re.findall(r"https?://[^\s)]+\?utm_source=openai", text)
+        pattern = r"https?://[^\s)]+(?:\?|&)utm_source=openai[^\s)]*"
+        matches = re.findall(pattern, text)
         return matches
 
     @staticmethod


### PR DESCRIPTION
## Summary
- fix missing return in `web_search_toggle_filter`'s `outlet`
- expand URL regex to capture utm_source links with additional params
- add regression test covering search models

## Testing
- `nox -s lint tests`