### PR TITLE
Pruned documentation for clarity

### DIFF
--- a/docs/openai_responses_api_pipeline_plan.md
+++ b/docs/openai_responses_api_pipeline_plan.md
@@ -1,145 +1,26 @@
 # OpenAI Responses API Pipeline Refactor Plan
 
-This refactor aims to make `functions/pipes/openai_responses_api_pipeline.py` easier to maintain and more closely aligned with WebUI’s built‑in middleware—while remaining a self‑contained, single‑file tool. All changes must preserve existing features such as streaming, parallel tool calls, reasoning summaries (`<think>` blocks), and usage stats.
+A short checklist for completing the rewrite of `openai_responses_api_pipeline.py`.
 
----
+## Goals
+- Keep the pipeline as a single file that can be dropped into any WebUI instance.
+- Match WebUI's middleware helpers and event ordering.
+- Support native tool calls, streaming and usage statistics.
+- Simplify the code so it is easier to maintain and test.
 
-## Refactor Goals
+## Implementation Outline
+1. Extract helpers for assembling the request, streaming SSE and executing tool calls.
+2. Rewrite `Pipe.pipe()` to orchestrate these helpers and remove any stored `previous_response_id` once done.
+3. Reuse functions from `open_webui.utils.middleware` where they fit.
+4. Expand unit tests to cover SSE parsing, tool execution and usage stats.
+5. Summarise the new structure in `functions/pipes/README.md`.
 
-1. **Maintain Single-File Design**  
-   So the pipeline can be copied into any Open WebUI instance with minimal friction.
+## Current Status
+- Helper functions exist but the new `pipe()` is still under construction.
+- Integration with middleware utilities is partially complete.
+- Tests and documentation need to be updated.
 
-2. **Align with WebUI Middleware**  
-   Match function naming, event emitter patterns, and usage stats tracking so the pipeline behaves like `process_chat_response`.
-
-3. **Native Tool Calls**  
-   Continue supporting OpenAI’s native function‑call style (tool calls) in an asynchronous, parallel manner.
-
-4. **Improve Readability & Testability**  
-   Break large logic into focused helpers with unit tests to ensure correctness.
-
-5. **Keep Existing Features**  
-   - Manual SSE streaming, `<think>` markers, asynchronous tool calls, web search integration, usage stats, logging, and limiting repeated loops with `MAX_TOOL_CALLS`.
-
----
-
-## High-Level Changes
-
-1. **Extract Utilities & Mirror Middleware**  
-   - Use (or closely mimic) utilities from `open_webui.utils.middleware`.  
-   - Remove duplicated code where possible.  
-   - Keep all logic in one file (don’t create a separate module).
-
-2. **Restructure `Pipe.pipe()`**  
-   - Break `pipe()` into smaller helpers:  
-     - *Input assembly* (prepares payload)  
-     - *Streaming loop* (listens to SSE)  
-     - *Tool execution* (runs calls in parallel)  
-    - *Storage/cleanup* (persist final response only; remove partial writes)
-   - Adopt event emitter conventions from WebUI (`status`, `citation`, `chat:completion`).
-
-3. **Tool Execution Helper**  
-   - Move `_execute_tools` to a dedicated helper that accepts a list of calls and returns results.  
-   - Store call inputs and outputs in the chat history (e.g., `tool_calls`, `tool_responses` fields).
-
-4. **Reasoning Tokens Persistence**  
-   - Use `previous_response_id` and `DELETE /v1/responses/{id}` to ensure raw reasoning tokens can be streamed and then cleaned up.
-
-5. **Configuration & Valves**  
-   - Provide fallback defaults.  
-   - Apply user overrides (e.g., `UserValves`) after defaults are set.
-
-6. **Testing & Documentation**  
-   - Add unit tests under `.tests/` with SSE parsing, usage stats, and parallel tool calls.  
-   - Update `functions/pipes/README.md` explaining new structure.
-
----
-
-## Detailed Implementation Tasks
-
-Below is a task breakdown with _suggested_ statuses. The AI (or human) can check off each item, note partial progress, and leave comments.
-
-> **Legend for Status**:  
-> - **Not Started**  
-> - **In Progress**  
-> - **Blocked**  
-> - **Done**  
-
-| **Task ID** | **Title**                                     | **Description**                                                                                                                                                                                                                               | **Status** | **Notes / Links** |
-|-------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|-------------------|
-| **1**       | **Extract Helpers**                           | 1. Create small, focused helper functions for SSE parsing and assembling OpenAI payloads.<br> 2. Preserve existing logic but isolate it in well‑named functions. <br> 3. Add placeholders in the code for future tests. | In Progress | `parse_responses_sse`, `execute_responses_tool_calls`, `assemble_responses_input` implemented. Removed obsolete `_build_params`; renamed `_execute_tool_calls` helper. Fixed dataclass mapping bug in `parse_responses_sse`. |
-| **2**       | **Refactor `pipe()`**                        | 1. Rewrite `Pipe.pipe()` to orchestrate the new helpers (payload building, streaming, tool calls, final cleanup). <br> 2. Keep the event emission order consistent with WebUI’s `process_chat_response`. <br> 3. Ensure partial results are stored properly. | In Progress |                   |
-| **3**       | **Integrate Middleware Imports**              | 1. Identify duplicated logic that can be replaced with `open_webui.utils.middleware` or similar. <br> 2. Replace references safely, ensuring no feature gaps.                                                                                     | In Progress |                   |
-| **4**       | **Implement Cleanup**                         | 1. After streaming and tool calls, call `DELETE /v1/responses/{id}` to remove stored responses if `previous_response_id` was used. <br> 2. Ensure errors do not block cleanup.                                                                    | In Progress |                   |
-| **5**       | **Expand Unit Tests**                         | 1. Add tests under `.tests/` mocking SSE events, verifying usage stats and parallel tool call flows. <br> 2. Confirm the final event order (status → message → citation → completion).                                                           | In Progress |                   |
-| **6**       | **Update Documentation**                      | 1. Revise `functions/pipes/README.md` with a short summary of the new structure. <br> 2. Note any external imports from middleware. <br> 3. Link to the new test suite for maintainers.                                                            | In Progress |                   |
-| **7**       | **Verify Event Logs & Compare**              | 1. Capture logs from a real chat session in both the old pipeline and the new one. <br> 2. Compare event sequences to ensure no regressions. | Blocked | Old pipeline version unavailable; cannot capture comparison logs |
-
----
-
-## Proposed File Structure
-
-Retain **one** file: `openai_responses_api_pipeline.py`. Within it:
-
-1. **Data Models**  
-   - `Valves`, `UserValves` (Pydantic or similar) for configuration.  
-   - `ResponsesEvent` (dataclass) for parsed SSE lines: includes `type`, `delta`, etc.
-
-2. **Helper Functions** (for example; names can vary):
-   - `async def assemble_responses_payload(valves: Valves, chat_id: str) -> dict`
-     Builds the input payload for the OpenAI Responses API.
-   - `parse_responses_sse(raw_sse_line: str) -> ResponsesEvent`  
-     Converts an SSE line into a typed event object.
-   - `stream_responses_completion(...) -> AsyncIterator[ResponsesEvent]`  
-     Streams SSE from the API, preserves `previous_response_id`.
-   - `execute_responses_tool_calls(tool_calls: list[dict], chat_id: str) -> list[dict]`  
-     Runs all requested tools asynchronously and returns results.
-   - `delete_openai_response(client, base_url, response_id)`  
-     Cleans up stored responses via `DELETE /v1/responses/{id}`.
-
-3. **`Pipe` Class**  
-   - `async def pipe(self, body, __user__, __request__, __emitter__, __caller__, __files__, __meta__, __tools__):`  
-     The orchestrator that ties everything together. Steps:  
-     1. Load config & chat data  
-     2. Assemble the request payload  
-     3. Stream & parse SSE events, emit them in real‑time  
-     4. Detect and handle tool calls  
-     5. Cleanup any stored `previous_response_id`
-
-
-Important Notes
-	•	Error Handling:
-Even if a tool call fails or the SSE stream breaks, emit a final chat:completion event and attempt to clean up previous_response_id.
-	•	MAX_TOOL_CALLS vs. MAX_TOOL_LOOPS:
-Consider renaming MAX_TOOL_CALLS to clarify it limits iterative loops of tool calls, not the total possible calls.
-	•	Storage of Reasoning Tokens:
-Because previous_response_id is used, partial model reasoning stays in the chain of responses. Once we’re done, we issue a DELETE to keep the response store clean.
-	•	Logging & Debug:
-Maintain the existing debug logging approach. Possibly buffer logs and emit them as a final citation in DEBUG mode.
-	•	Parallel Tool Execution:
-Use asyncio.gather for tool calls if multiple calls come in at once.
-        •       Streaming Performance:
-Initial SSE parsing relied on ``json.loads`` with ``object_hook``.  The
-implementation now parses only the top-level keys and converts nested
-structures on demand.  Annotation regexes are precompiled and debug formatting
-is wrapped in ``DEBUG`` checks to further cut CPU cost.  Unused
-``to_obj``/``to_dict`` helpers were dropped and usage aggregation no longer
-recursively copies objects.  Parsed SSE events now use a ``dataclass`` with
-``slots=True`` and direct field mapping to reduce per-event overhead.
-
-⸻
-
-Next Steps
-	•	(1) Begin Helper Extraction: Introduce new helper functions without breaking the old flow.
-	•	(2) Incrementally Refactor: Migrate logic from _execute_tools and other large code blocks into the new helpers.
-	•	(3) Integrate & Test: Ensure references to new helpers align with WebUI middleware. Write tests as changes are made to prevent regressions.
-	•	(4) Finalize & Cleanup: Remove unused code, add docstrings, finalize documentation in README.md.
-
-As each task is completed, update the Task Table’s status column. This will keep the refactoring organized and easy to track.
-
-⸻
-
-End of Plan
-
-Use this document as a single source of truth for the refactoring effort. Each time new commits are made to production, update the “Task ID” row accordingly and note any special considerations in the “Notes / Links” column.  Let items as In Progress until they are perfected.
-
+## Next Steps
+1. Finalise the refactor and ensure events match `process_chat_response`.
+2. Add comprehensive tests for streaming and tool flows.
+3. Keep this document updated as tasks are finished.

--- a/functions/filters/README.md
+++ b/functions/filters/README.md
@@ -1,51 +1,31 @@
 # Filters Guide
 
-Filters are lightweight plugins that run **alongside pipes**.  They intercept chat
-traffic at three points – before a request hits the model, while the model streams
-tokens and once the full response is produced.  Picture the pipeline as a stream of
-water: each filter is a treatment step that can enrich, sanitise or log the flow
-without replacing the underlying pipe.  Filters are stored as single Python files
-and the loader invokes whichever handlers they implement.
+Filters are lightweight plugins that run before, during and after a pipe. Each file can define `inlet`, `stream` and `outlet` handlers to modify chat data or emit events.
 
-Filter IDs are resolved by `get_sorted_filter_ids`, which merges globally enabled
-filters with those declared on a model and sorts them by `Valves.priority`.
-
-## How Filters Fit in the Pipeline
-
-1. **inlet** – runs on the request body before the pipe executes. Use it to add
-   context, scrub data or block unwanted content.
-2. **pipe** – generates the assistant reply (not covered here).
-3. **stream** – intercepts each chunk of the assistant's reply while streaming.
-4. **outlet** – processes the full response payload once the pipe is done.
-
-By chaining multiple filters you can shape the conversation without modifying the
-underlying pipe logic.
+## Basic Structure
 
 ```python
-class Filter:
-    async def inlet(self, body):
-        """Optional: run before the pipe."""
-        return body
+from pydantic import BaseModel
 
-    async def outlet(self, body):
-        """Optional: run after the pipe returns."""
+class Filter:
+    class Valves(BaseModel):
+        priority: int = 0
+
+    async def inlet(self, body):
         return body
 
     async def stream(self, event):
-        """Optional: inspect each streamed token."""
         return event
+
+    async def outlet(self, body):
+        return body
 ```
 
-Only the methods you implement are called. They may be synchronous or `async`.
+Only the methods you implement are called. `priority` controls execution order when multiple filters are active.
 
-## Loading and frontmatter
+## Loading
 
-Filter files live in the database and are fetched on demand.
-`utils.plugin.load_function_module_by_id` rewrites short import paths (e.g.
-`from utils.chat` → `from open_webui.utils.chat`), installs any packages listed
-in a triple quoted **frontmatter** block and executes the file. If the module
-exposes `Filter`, the resulting object is cached under
-`request.app.state.FUNCTIONS` and reused for later requests.
+Upload the file via the Functions API. Optional packages can be listed in a frontmatter block and will be installed automatically:
 
 ```python
 """
@@ -53,164 +33,12 @@ requirements: httpx
 """
 ```
 
-The `requirements` list is installed with `pip` before the filter runs. Other
-fields are available as metadata.
+The loader caches each module under `request.app.state.FUNCTIONS`.
 
-## Configuration via Valves
+## Valves and User Settings
 
-Filters may expose adjustable settings by defining `Valves` and `UserValves`
-classes. These inherit from `pydantic.BaseModel` and are populated from the
-server database on each call:
+Filters may expose extra options via `Valves` and `UserValves` classes. These are hydrated from the database on each call so settings can be tweaked without re-uploading the code.
 
-```python
-from pydantic import BaseModel
+Set `file_handler = True` if the filter consumes uploaded files itself. Only parameters declared in a handler's signature are provided (e.g. `body`, `event`, `__user__`).
 
-class Valves(BaseModel):
-    priority: int = 0
-
-class UserValves(BaseModel):
-    quota: int = 5
-```
-
-Values can be updated through the Functions API without re-uploading the code.
-`priority` decides the order filters run—the higher the value the later it
-executes.
-
-Set `file_handler = True` when the filter consumes uploaded files itself. The
-middleware then removes them from the payload.
-
-`process_filter_functions` retrieves the module from
-`request.app.state.FUNCTIONS` if it has been loaded previously and only then
-executes the appropriate handler. When the handler is synchronous it runs
-directly; otherwise it is awaited.
-
-## Parameter injection
-
-`process_filter_functions` inspects each handler's signature with
-`inspect.signature` and only supplies the parameters it explicitly declares. The
-following names are commonly available:
-
-- `body` – request/response payload for `inlet` and `outlet` methods
-- `event` – single streaming event for `stream`
-- `__id__` – filter id
-- `__event_emitter__` – send updates to the browser
-- `__event_call__` – display a dialog and await a response
-- `__user__` – current user info and optional `UserValves` instance
-- `__metadata__` – chat/session identifiers
-- `__request__` – the `fastapi.Request` object
-- `__model__` – model data
-
-Extra context can be injected using the same variable names.
-
-## Middleware integration
-
-`process_chat_payload` in the WebUI middleware builds the `extra_params`
-dictionary containing event callbacks, user info and metadata.  This dictionary
-is passed to `process_filter_functions` so every filter can access the same
-helpers that pipes do.  Filters execute before the selected pipe runs and again
-while streaming tokens back to the client.  See
-`external/MIDDLEWARE_GUIDE.md` for a deeper walkthrough of the request flow.
-
-## Filter lifecycle
-
-1. `get_sorted_filter_ids` merges globally enabled functions with the
-   model's `meta.filterIds` list and sorts them by `Valves.priority`. Only
-   functions that are marked active are returned.
-2. Each filter module is loaded (or reused from
-   `request.app.state.FUNCTIONS`) and its handler method is invoked via
-   `process_filter_functions`.
-3. Valves and per‑user settings are hydrated before the call and only the
-   parameters declared in the method signature are passed.
-4. When `file_handler` is true the middleware removes `files` from the payload
-   after the `inlet` call so the filter can process them itself.
-
-Filters can raise exceptions to abort the request. Streaming filters can inspect
-or modify each token before it reaches the client.
-
-### Example
-
-A filter that enforces a turn limit and logs streamed tokens:
-
-```python
-from pydantic import BaseModel
-
-class Valves(BaseModel):
-    max_turns: int = 4
-
-class UserValves(BaseModel):
-    bonus_turns: int = 0
-
-file_handler = True
-
-class Filter:
-    def inlet(self, body, __user__, valves):
-        limit = valves.max_turns + __user__.valves.bonus_turns
-        if len(body.get("messages", [])) > limit:
-            raise Exception(f"Conversation turn limit exceeded ({limit})")
-        return body
-
-    async def stream(self, event):
-        print("token", event.get("data"))
-        return event
-```
-
-Place filter modules in this folder. They can be combined with any pipe to
-customise the chat pipeline.
-
-Other patterns include adding system context or formatting the assistant reply:
-
-```python
-class Filter:
-    def inlet(self, body: dict) -> dict:
-        body.setdefault("messages", []).insert(
-            0, {"role": "system", "content": "You are a helpful assistant."}
-        )
-        return body
-
-    def outlet(self, body: dict) -> dict:
-        for msg in body.get("messages", []):
-            if msg.get("role") == "assistant":
-                msg["content"] = f"**{msg['content']}**"
-        return body
-```
-
-### Toggle Filter Example (Open WebUI 0.6.10)
-
-Filters may show a switch in the UI and a custom icon when `toggle` and `icon`
-are defined. The example below emits a status toast when toggled:
-
-```python
-from pydantic import BaseModel
-from typing import Optional
-
-class Filter:
-    class Valves(BaseModel):
-        pass
-
-    def __init__(self):
-        self.valves = self.Valves()
-        self.toggle = True  # adds a UI switch
-        # small SVG encoded as a data URI
-        self.icon = "data:image/svg+xml;base64,..."
-
-    async def inlet(
-        self, body: dict, __event_emitter__, __user__: Optional[dict] = None
-    ) -> dict:
-        await __event_emitter__(
-            {
-                "type": "status",
-                "data": {
-                    "description": "Toggled!",
-                    "done": True,
-                    "hidden": False,
-                },
-            }
-        )
-        return body
-```
-
-A screenshot of the toggle in action can be found [here](https://docs.openwebui.com/assets/images/toggle-filter-491e8306ef6b94f72cd5236c7944043d.png).
-
-More implementation details and code snippets can be found in
-`external/FILTER_GUIDE.md` which summarises the upstream
-`open_webui.utils.filter` module.
+See `external/FILTER_GUIDE.md` for deeper middleware notes and additional examples.


### PR DESCRIPTION
## Summary
- shorten `openai_responses_api_pipeline_plan.md`
- condense `functions/filters` guide

## Testing
- `nox -s lint tests`