### PR TITLE
Add standard response support

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -330,7 +330,7 @@ async def test_pipe_stream_loop(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
         gen = pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             emitter,
@@ -374,7 +374,7 @@ async def test_pipe_deletes_response(dummy_chat):
         pipeline, "delete_response", AsyncMock()
     ) as del_mock, patch.object(pipe, "get_http_client", AsyncMock(return_value=object())):
         await pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             emitter,
@@ -424,7 +424,7 @@ async def test_debug_logs_citation_emitted(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
         await pipe.pipe(
-            {},
+            {"stream": True},
             user,
             None,
             emitter,
@@ -468,7 +468,7 @@ async def test_debug_logs_citation_saved_with_tool(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ), patch.object(pipe, "_store_citation") as store_mock:
         await pipe.pipe(
-            {},
+            {"stream": True},
             user,
             None,
             AsyncMock(),
@@ -528,7 +528,7 @@ async def test_debug_logs_citation_multiple_turns(dummy_chat):
         side_effect=[fake_stream1, fake_stream2],
     ), patch.object(pipe, "get_http_client", AsyncMock(return_value=object())):
         gen = pipe.pipe(
-            {},
+            {"stream": True},
             user,
             None,
             emitter,
@@ -572,7 +572,7 @@ async def test_tool_metadata_persisted(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
         await pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             emitter,
@@ -630,7 +630,7 @@ async def test_previous_response_cleanup(dummy_chat):
         AsyncMock(return_value=object()),
     ):
         await pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             AsyncMock(),
@@ -689,7 +689,7 @@ async def test_function_call_output_persisted(dummy_chat):
                 srcs.append(evt["data"])
                 m["sources"] = srcs
         gen = pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             emitter,
@@ -751,7 +751,7 @@ async def test_persist_tool_results_valve_off(dummy_chat):
                 srcs.append(evt["data"])
                 m["sources"] = srcs
         gen = pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             emitter,
@@ -808,7 +808,7 @@ async def test_tools_removed_for_unsupported_model(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
         await pipe.pipe(
-            {"model": "openai_responses.chatgpt-4o-latest"},
+            {"model": "openai_responses.chatgpt-4o-latest", "stream": True},
             {},
             None,
             AsyncMock(),
@@ -883,13 +883,51 @@ async def test_pipe_without_emitter(dummy_chat):
         pipe, "get_http_client", AsyncMock(return_value=object())
     ):
         gen = pipe.pipe(
-            {},
+            {"stream": True},
             {},
             None,
             None,
             AsyncMock(),
             [],
             {},
+            {},
+        )
+        tokens = []
+        async for t in gen:
+            tokens.append(t)
+    await pipe.on_shutdown()
+    assert tokens == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_pipe_standard_response(dummy_chat):
+    pipeline = _reload_pipeline()
+    pipe = pipeline.Pipe()
+
+    async def fake_fetch(client, base_url, api_key, params):
+        assert params["stream"] is False
+        return {
+            "id": "r1",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+            "usage": {},
+        }
+
+    with patch.object(pipeline, "fetch_response", fake_fetch), patch.object(
+        pipe, "get_http_client", AsyncMock(return_value=object())
+    ), patch.object(pipeline, "delete_response", AsyncMock()):
+        gen = pipe.pipe(
+            {"stream": False},
+            {},
+            None,
+            None,
+            AsyncMock(),
+            [],
+            {"chat_id": "chat1", "message_id": "m1", "function_calling": "native"},
             {},
         )
         tokens = []

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -337,6 +337,8 @@ class Pipe:
         if "." in str(model):
             model = str(model).split(".", 1)[1]
 
+        streaming = body.get("stream", False)
+
         tools: list[dict[str, Any]] | None
         if model in NATIVE_TOOL_UNSUPPORTED_MODELS:
             tools = None
@@ -361,6 +363,7 @@ class Pipe:
             instructions,
             tools,
             __user__.get("email"),
+            stream=streaming,
         )
         request_params = base_params
         usage_total: dict[str, Any] = {}
@@ -396,17 +399,18 @@ class Pipe:
 
             try:
                 pending_calls: list[SimpleNamespace] = []
-                if self.log.isEnabledFor(logging.DEBUG):
-                    self.log.debug("response_stream created for loop #%d", loop_count)
-                async for event in stream_responses(
-                    client,
-                    valves.BASE_URL,
-                    valves.API_KEY,
-                    request_params,
-                ):
-                    et = event.type
+                if streaming:
                     if self.log.isEnabledFor(logging.DEBUG):
-                        self.log.debug("Event received: %s", et)
+                        self.log.debug("response_stream created for loop #%d", loop_count)
+                    async for event in stream_responses(
+                        client,
+                        valves.BASE_URL,
+                        valves.API_KEY,
+                        request_params,
+                    ):
+                        et = event.type
+                        if self.log.isEnabledFor(logging.DEBUG):
+                            self.log.debug("Event received: %s", et)
 
                     if et == "response.created":
                         if last_response_id:
@@ -491,6 +495,22 @@ class Pipe:
                                 usage_total, event.response.usage, loop_count
                             )
                         continue
+                else:
+                    resp_json = await fetch_response(
+                        client,
+                        valves.BASE_URL,
+                        valves.API_KEY,
+                        request_params,
+                    )
+                    if last_response_id:
+                        cleanup_ids.append(last_response_id)
+                    last_response_id = resp_json.get("id")
+                    text_block = extract_output_text(resp_json)
+                    if text_block:
+                        yield text_block
+                    if resp_json.get("usage"):
+                        self._update_usage(usage_total, resp_json.get("usage"), loop_count)
+                    break
             except Exception as ex:
                 self.log.error("Error in pipeline loop %d: %s", loop_count, ex)
                 if __event_emitter__:
@@ -923,6 +943,24 @@ async def stream_responses(
                 event_type = line[len("event:"):].strip()
             elif line.startswith("data:"):
                 data_buf.append(line[len("data:"):].strip())
+
+
+async def fetch_response(
+    client: httpx.AsyncClient,
+    base_url: str,
+    api_key: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the JSON response from the API when ``stream`` is False."""
+
+    url = base_url.rstrip("/") + "/responses"
+    headers = {
+        "Authorization": f"Bearer {api_key.strip()}",
+        "Content-Type": "application/json",
+    }
+    resp = await client.post(url, headers=headers, json=params)
+    resp.raise_for_status()
+    return resp.json()
 async def delete_response(
     client: httpx.AsyncClient, base_url: str, api_key: str, response_id: str
 ) -> None:
@@ -1082,6 +1120,8 @@ async def assemble_responses_payload(
     tools: list[dict[str, Any]] | None,
     user_email: str | None,
     input_messages: list[dict] | None = None,
+    *,
+    stream: bool = True,
 ) -> dict[str, Any]:
     """Combine chat history and parameters into a request payload.
 
@@ -1106,7 +1146,7 @@ async def assemble_responses_payload(
         "user": user_email,
         "text": {"format": {"type": "text"}},
         "truncation": "auto",
-        "stream": True,
+        "stream": stream,
         "store": True,
         "input": input_messages,
     }
@@ -1153,6 +1193,18 @@ def parse_responses_sse(event_type: str | None, data: str) -> ResponsesEvent:
         response=response,
         annotation=annotation,
     )
+
+
+def extract_output_text(response: dict[str, Any]) -> str:
+    """Return concatenated output_text blocks from a response payload."""
+    texts: list[str] = []
+    for item in response.get("output", []):
+        if item.get("type") != "message":
+            continue
+        for part in item.get("content", []):
+            if isinstance(part, dict) and part.get("type") == "output_text":
+                texts.append(str(part.get("text", "")))
+    return "".join(texts)
 
 
 async def execute_responses_tool_calls(


### PR DESCRIPTION
## Summary
- handle `stream` parameter in OpenAI responses pipeline
- support non-streaming responses via new `fetch_response` helper
- add `extract_output_text` parser utility
- update tests to set `stream=True` when needed and cover standard responses

## Testing
- `nox -s lint tests`