### PR TITLE
Fix Web Search tool clearing

### DIFF
--- a/.tests/test_web_search_toggle_filter.py
+++ b/.tests/test_web_search_toggle_filter.py
@@ -48,6 +48,7 @@ async def test_search_preview_for_other_models():
     out = await flt.inlet(body, __tools__=reg)
     assert out["model"] == "gpt-4o-search-preview"
     assert any(t.get("type") == "web_search" for t in reg.get("tools", []))
+    assert out["tools"] is None
 
 
 def test_outlet_handles_missing_emitter():

--- a/functions/filters/web_search_toggle_filter.py
+++ b/functions/filters/web_search_toggle_filter.py
@@ -106,6 +106,11 @@ class Filter:
 
         self._add_web_search_tool(body, __tools__)
 
+        # GPT-4o Search Preview doesn't support normal tool calling. Ensure the
+        # request payload clears the ``tools`` field so any previously
+        # configured tools are ignored by the pipeline.
+        body["tools"] = None
+
         return body
 
     async def outlet(self, body: dict, __event_emitter__=None) -> dict:


### PR DESCRIPTION
## Summary
- set tools to `None` when routing to GPT‑4o Search Preview
- check for the `None` value in tests

## Testing
- `nox -s lint tests`