### PR TITLE
Refactor responses pipeline helpers

### DIFF
--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -21,8 +21,9 @@ When `MODEL_ID` contains multiple comma separated values the pipe becomes a
 This repository's larger pipelines also include small helper functions for
 building the request payload, streaming Server-Sent Events (SSE), and executing
 tool calls.  See `openai_responses_api_pipeline.py` for async helpers such as
-`assemble_responses_payload`, `assemble_responses_input`, `stream_responses`,
-`get_responses`, `extract_response_text`, and `execute_responses_tool_calls`.
+`prepare_payload`, `load_chat_input`, `transform_messages_for_responses_api`,
+`stream_responses`, `get_responses`, `extract_response_text`, and
+`execute_responses_tool_calls`.
 
 Additional valves for injecting the current date and user context are documented in
 `docs/instruction_injection_valves.md`.


### PR DESCRIPTION
## Summary
- clarify message transformation helpers
- rename to `transform_messages_for_responses_api`
- restore `truncation: auto` when preparing API payload

## Testing
- `nox -s lint tests`