### PR TITLE
Fix tool format for Responses API

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -37,21 +37,15 @@ def test_transform_tools_for_responses_api_variants(dummy_chat):
     assert tools == [
         {
             "type": "function",
-            "function": {
-                "name": "foo",
-                "description": "d",
-                "parameters": {"type": "object"},
-                "strict": True,
-            },
+            "name": "foo",
+            "description": "d",
+            "parameters": {"type": "object"},
         },
         {
             "type": "function",
-            "function": {
-                "name": "bar",
-                "description": "",
-                "parameters": {"type": "object"},
-                "strict": True,
-            },
+            "name": "bar",
+            "description": "",
+            "parameters": {"type": "object"},
         },
     ]
 

--- a/docs/pipe_input.md
+++ b/docs/pipe_input.md
@@ -45,16 +45,14 @@ Example:
   "tools": [
     {
       "type": "function",
-      "function": {
-        "name": "calculator",
-        "description": "Accurate math expressions, etc.",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "expression": {"type": "string", "description": "..."}
-          },
-          "required": ["expression"]
-        }
+      "name": "calculator",
+      "description": "Accurate math expressions, etc.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "expression": {"type": "string", "description": "..."}
+        },
+        "required": ["expression"]
       }
     }
   ]

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -959,12 +959,9 @@ def transform_tools_for_responses_api(
         tools_responses_api_json.append(
             {
                 "type": "function",
-                "function": {
-                    "name": function_spec.get("name"),
-                    "description": function_spec.get("description", ""),
-                    "parameters": function_spec.get("parameters", {"type": "object"}),
-                    "strict": False,
-                },
+                "name": function_spec.get("name"),
+                "description": function_spec.get("description", ""),
+                "parameters": function_spec.get("parameters", {"type": "object"}),
             }
         )
 


### PR DESCRIPTION
## Summary
- output tool metadata in Responses API format
- update docs to match new tool structure
- adjust tests for updated tool format

## Testing
- `nox -s lint tests`