### PR TITLE
Fix tool type handling in pipeline

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -50,6 +50,13 @@ def test_transform_tools_for_responses_api_variants(dummy_chat):
     ]
 
 
+def test_transform_tools_for_responses_api_keeps_non_function(dummy_chat):
+    pipeline = _reload_pipeline()
+    body_tools = [{"type": "web_search", "search_context_size": "medium"}]
+    tools = pipeline.transform_tools_for_responses_api(body_tools)
+    assert tools == body_tools
+
+
 @pytest.mark.asyncio
 async def test_build_responses_payload(dummy_chat):
     pipeline = _reload_pipeline()

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -960,15 +960,19 @@ def transform_tools_for_responses_api(
     for tool in tools_completion_api_json or []:
         if not isinstance(tool, dict):
             continue
-        function_spec = tool.get("function", tool)
-        tools_responses_api_json.append(
-            {
-                "type": "function",
-                "name": function_spec.get("name"),
-                "description": function_spec.get("description", ""),
-                "parameters": function_spec.get("parameters", {"type": "object"}),
-            }
-        )
+        tool_type = tool.get("type")
+        if tool_type == "function" or "function" in tool:
+            function_spec = tool.get("function", tool)
+            tools_responses_api_json.append(
+                {
+                    "type": "function",
+                    "name": function_spec.get("name"),
+                    "description": function_spec.get("description", ""),
+                    "parameters": function_spec.get("parameters", {"type": "object"}),
+                }
+            )
+        else:
+            tools_responses_api_json.append(tool)
 
     return tools_responses_api_json
 


### PR DESCRIPTION
## Summary
- avoid transforming non-`function` tools in `transform_tools_for_responses_api`
- test that non-function tools remain unchanged

## Testing
- `nox -s lint tests`