### PR TITLE
Add image generation filter and pipeline support

### DIFF
--- a/.tests/test_create_image_filter.py
+++ b/.tests/test_create_image_filter.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
+import pytest
+
+
+def _load_filter():
+    path = Path(__file__).resolve().parents[1] / "functions" / "filters" / "create_image_filter.py"
+    spec = spec_from_file_location("create_image_filter", path)
+    mod = module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.asyncio
+async def test_add_image_generation_tool():
+    mod = _load_filter()
+    flt = mod.Filter()
+    body = {"model": "openai_responses.gpt-4.1"}
+    out = await flt.inlet(body)
+    assert any(t.get("type") == "image_generation" for t in out.get("tools", []))
+
+
+@pytest.mark.asyncio
+async def test_no_duplicate_image_generation_tool():
+    mod = _load_filter()
+    flt = mod.Filter()
+    body = {"tools": [{"type": "image_generation", "size": "auto", "quality": "auto"}]}
+    out = await flt.inlet(body)
+    assert len([t for t in out["tools"] if t.get("type") == "image_generation"]) == 1

--- a/functions/filters/create_image_filter.py
+++ b/functions/filters/create_image_filter.py
@@ -1,0 +1,37 @@
+"""
+title: Create an Image
+id: create_image_filter
+description: Injects the image_generation tool with configurable size and quality.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Filter:
+    class Valves(BaseModel):
+        SIZE: str = "auto"
+        QUALITY: str = "auto"
+
+    def __init__(self) -> None:
+        self.valves = self.Valves()
+        self.toggle = True
+        self.icon = (
+            "data:image/svg+xml;base64,"
+            "PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0ibm9uZSIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIHN0cm9rZS13aWR0aD0iMiIgZD0iTTIgNmg0bDYtN2g0bDggOHY5SDJ6Ii8+PC9zdmc+"
+        )
+
+    def _add_image_generation_tool(self, body: dict) -> None:
+        entry = {
+            "type": "image_generation",
+            "size": self.valves.SIZE,
+            "quality": self.valves.QUALITY,
+        }
+        tools = body.setdefault("tools", [])
+        if not any(t.get("type") == "image_generation" for t in tools):
+            tools.append(entry)
+
+    async def inlet(self, body: dict, **_kwargs) -> dict:
+        self._add_image_generation_tool(body)
+        return body

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -102,6 +102,8 @@ class ResponsesEvent:
     item: Any | None = None
     response: Any | None = None
     annotation: Any | None = None
+    partial_image_index: int | None = None
+    partial_image_b64: str | None = None
 
 
 class _MemHandler(logging.Handler):
@@ -467,6 +469,40 @@ class Pipe:
                     if et == "response.output_text.done":
                         # This delta marks the end of the current output block.
                         continue
+                    if et in {
+                        "response.image_generation_call.in_progress",
+                        "response.image_generation_call.generating",
+                    }:
+                        await self._emit_status(
+                            __event_emitter__,
+                            "🖼️ Generating image...",
+                            last_status,
+                        )
+                        continue
+                    if et == "response.image_generation_call.partial_image":
+                        if __event_emitter__ and event.partial_image_b64:
+                            await __event_emitter__(
+                                {
+                                    "type": "files",
+                                    "data": {
+                                        "files": [
+                                            {
+                                                "type": "image",
+                                                "url": f"data:image/png;base64,{event.partial_image_b64}",
+                                            }
+                                        ]
+                                    },
+                                }
+                            )
+                        continue
+                    if et == "response.image_generation_call.completed":
+                        await self._emit_status(
+                            __event_emitter__,
+                            "🖼️ Image generation completed",
+                            last_status,
+                            done=True,
+                        )
+                        continue
                     if et == "response.output_item.added":
                         item = getattr(event, "item", None)
                         if getattr(item, "type", None) == "function_call":
@@ -496,6 +532,27 @@ class Pipe:
                             await self._emit_status(
                                 __event_emitter__,
                                 "🔍 Searching the internet...",
+                                last_status,
+                                done=True,
+                            )
+                        elif getattr(item, "type", None) == "image_generation_call":
+                            if __event_emitter__ and getattr(item, "result", None):
+                                await __event_emitter__(
+                                    {
+                                        "type": "files",
+                                        "data": {
+                                            "files": [
+                                                {
+                                                    "type": "image",
+                                                    "url": f"data:image/png;base64,{item.result}",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                )
+                            await self._emit_status(
+                                __event_emitter__,
+                                "🖼️ Image generation completed",
                                 last_status,
                                 done=True,
                             )
@@ -1205,6 +1262,8 @@ def parse_responses_sse(event_type: str | None, data: str) -> ResponsesEvent:
         item=item,
         response=response,
         annotation=annotation,
+        partial_image_index=payload.get("partial_image_index"),
+        partial_image_b64=payload.get("partial_image_b64"),
     )
 
 


### PR DESCRIPTION
## Summary
- new `create_image_filter` injects `image_generation` tool with customizable size and quality options
- extend `openai_responses_api_pipeline` with image event handling
- include tests for the new filter

## Testing
- `nox -s lint tests`