### PR TITLE
Add doc on chat title generation

### DIFF
--- a/.tests/test_dynamic_title_pipe.py
+++ b/.tests/test_dynamic_title_pipe.py
@@ -1,0 +1,47 @@
+import sys
+import types
+from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
+
+import pytest
+
+
+def _load_pipe(title_store):
+    mods = {
+        "open_webui": types.ModuleType("open_webui"),
+        "open_webui.models": types.ModuleType("open_webui.models"),
+        "open_webui.models.chats": types.ModuleType("open_webui.models.chats"),
+    }
+
+    mods["open_webui.models.chats"].Chats = types.SimpleNamespace(
+        update_chat_title_by_id=lambda cid, t: title_store.__setitem__(cid, t),
+        get_chat_title_by_id=lambda cid: title_store.get(cid),
+    )
+
+    with pytest.MonkeyPatch.context() as m:
+        m.context()
+        for name, mod in mods.items():
+            m.setitem(sys.modules, name, mod)
+        path = Path(__file__).resolve().parents[1] / "functions" / "pipes" / "dynamic_title_update_demo.py"
+        spec = spec_from_file_location("dynamic_title_update_demo", path)
+        pipe_mod = module_from_spec(spec)
+        sys.modules[spec.name] = pipe_mod
+        spec.loader.exec_module(pipe_mod)
+        return pipe_mod
+
+
+@pytest.mark.asyncio
+async def test_dynamic_title_updates():
+    titles = {}
+    mod = _load_pipe(titles)
+    pipe = mod.Pipe()
+
+    body = {"messages": [{"role": "user", "content": "hello"}]}
+    metadata = {"chat_id": "c1"}
+    request = types.SimpleNamespace(app=types.SimpleNamespace(state=types.SimpleNamespace(config=types.SimpleNamespace(ENABLE_TITLE_GENERATION=True))))
+
+    async for _ in pipe.pipe(body, metadata, request):
+        pass
+
+    assert titles["c1"].startswith("Completed")
+    assert request.app.state.config.ENABLE_TITLE_GENERATION is True

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 This folder stores internal notes and planning documents for extensions. Files here are not part of the runtime package.
 
 - `pipe_input.md` – details the full structure of arguments passed to a pipe's `pipe()` method.
+- `chat_title.md` – explains how chat titles are generated and updated.

--- a/docs/chat_title.md
+++ b/docs/chat_title.md
@@ -1,0 +1,175 @@
+# Chat Title Generation
+
+This note summarises how Open WebUI creates and updates chat titles.
+
+## Backend endpoint
+
+`backend/open_webui/routers/tasks.py` exposes a POST endpoint `/title/completions` that builds a prompt from recent messages and forwards it to the task model:
+
+```python
+@router.post("/title/completions")
+async def generate_title(request: Request, form_data: dict, user=Depends(get_verified_user)):
+    ...
+    payload = {
+        "model": task_model_id,
+        "messages": [{"role": "user", "content": content}],
+        "stream": False,
+        "metadata": {
+            ...,
+            "task": str(TASKS.TITLE_GENERATION),
+            "task_body": form_data,
+            "chat_id": form_data.get("chat_id", None),
+        },
+    }
+    return await generate_chat_completion(request, form_data=payload, user=user)
+```
+【F:external/open-webui/backend/open_webui/routers/tasks.py†L143-L231】
+
+The handler constructs a prompt using `title_generation_template` and sends it to `generate_chat_completion`. The response contains a JSON block like `{ "title": "..." }`.
+
+## Background task
+
+During a chat request, `process_chat_response` schedules a background task that calls `generate_title` once the main reply is done:
+
+```python
+if tasks and messages:
+    if TASKS.TITLE_GENERATION in tasks:
+        if tasks[TASKS.TITLE_GENERATION]:
+            res = await generate_title(request, {...}, user)
+            ...
+            Chats.update_chat_title_by_id(metadata["chat_id"], title)
+            await event_emitter({"type": "chat:title", "data": title})
+        elif len(messages) == 2:
+            title = messages[0].get("content", "New Chat")
+            Chats.update_chat_title_by_id(metadata["chat_id"], title)
+            await event_emitter({"type": "chat:title", "data": message.get("content", "New Chat")})
+```
+【F:external/open-webui/backend/open_webui/utils/middleware.py†L983-L1038】
+
+This updates the database via `Chats.update_chat_title_by_id` and emits a `chat:title` websocket event so the frontend refreshes the chat list.
+
+## Database helper
+
+`Chats.update_chat_title_by_id` writes the new title back to the stored chat JSON:
+
+```python
+def update_chat_title_by_id(self, id: str, title: str) -> Optional[ChatModel]:
+    chat = self.get_chat_by_id(id)
+    if chat is None:
+        return None
+    chat = chat.chat
+    chat["title"] = title
+    return self.update_chat_by_id(id, chat)
+```
+【F:external/open-webui/backend/open_webui/models/chats.py†L175-L183】
+
+## Frontend behaviour
+
+`chatTitle` is a writable store used across the UI:
+
+```ts
+export const chatId = writable('');
+export const chatTitle = writable('');
+```
+【F:external/open-webui/src/lib/stores/index.ts†L46-L48】
+
+When a `chat:title` event arrives, the current page and chat list are refreshed:
+
+```svelte
+} else if (type === 'chat:title') {
+    chatTitle.set(data);
+    currentChatPage.set(1);
+    await chats.set(await getChatList(localStorage.token, $currentChatPage));
+}
+```
+【F:external/open-webui/src/lib/components/chat/Chat.svelte†L288-L296】
+
+The page `<title>` element binds to `$chatTitle` so the browser tab updates automatically:
+
+```svelte
+<svelte:head>
+    <title>
+        {$chatTitle ? `${$chatTitle.length > 30 ? `${$chatTitle.slice(0, 30)}...` : $chatTitle} • ${$WEBUI_NAME}` : `${$WEBUI_NAME}`}
+    </title>
+</svelte:head>
+```
+【F:external/open-webui/src/lib/components/chat/Chat.svelte†L1978-L1984】
+
+### Manual title generation
+
+Each chat row in the sidebar has a "Generate" button that calls the task endpoint and then updates the title:
+
+```svelte
+const generateTitleHandler = async () => {
+    generating = true;
+    if (!chat) {
+        chat = await getChatById(localStorage.token, id);
+    }
+    const messages = (chat.chat?.messages ?? []).map((message) => ({
+        role: message.role,
+        content: message.content
+    }));
+    const model = chat.chat.models.at(0) ?? chat.models.at(0) ?? '';
+    chatTitle = '';
+    const generatedTitle = await generateTitle(localStorage.token, model, messages).catch((error) => {
+        toast.error(`${error}`);
+        return null;
+    });
+    if (generatedTitle) {
+        if (generatedTitle !== title) {
+            editChatTitle(id, generatedTitle);
+        }
+        confirmEdit = false;
+    } else {
+        chatTitle = title;
+    }
+    generating = false;
+};
+```
+【F:external/open-webui/src/lib/components/layout/Sidebar/ChatItem.svelte†L229-L264】
+
+`editChatTitle` ultimately calls `updateChatById` through the `/chats/{id}` API endpoint.
+
+## Retrieving a title
+
+To fetch a chat including its title, use `GET /chats/{id}` which maps to `get_chat_by_id` in `routers/chats.py`.
+
+### API example
+
+```bash
+GET /api/v1/chats/<chat_id>
+```
+The JSON response contains a `title` field alongside the `history` object.
+
+## Programmatic access
+
+Because pipes run inside the same process as WebUI you can import the `Chats`
+helper to read or modify a title at any point:
+
+```python
+from open_webui.models.chats import Chats
+
+current = Chats.get_chat_title_by_id(chat_id)
+Chats.update_chat_title_by_id(chat_id, "My custom title")
+```
+
+When you set a title manually you normally want to stop the automatic generator
+from overwriting it.  Pass `background_tasks: {"title_generation": false}` in the
+request body or toggle the setting directly:
+
+```python
+old = __request__.app.state.config.ENABLE_TITLE_GENERATION
+__request__.app.state.config.ENABLE_TITLE_GENERATION = False
+try:
+    # update titles during long running work
+    ...
+finally:
+    __request__.app.state.config.ENABLE_TITLE_GENERATION = old
+```
+
+See `functions/pipes/dynamic_title_update_demo.py` for a minimal pipeline that
+updates the title while it works.
+
+---
+
+**In short**: the backend generates a title asynchronously after each response, updates the database, and emits a `chat:title` event. The UI listens for this event to update its stores and the browser tab. Users can also trigger `/title/completions` manually via the sidebar button, which posts the chat messages and chosen model to the same endpoint.

--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -29,3 +29,7 @@ in `docs/instruction_injection_valves.md`.
 
 For a deep dive into the structure of arguments supplied to `pipe()`, see
 `docs/pipe_input.md`.
+
+Example:
+
+- `dynamic_title_update_demo.py` – updates the chat title while work is in progress.

--- a/functions/pipes/dynamic_title_update_demo.py
+++ b/functions/pipes/dynamic_title_update_demo.py
@@ -1,0 +1,50 @@
+"""
+title: Dynamic Title Update Demo
+id: dynamic_title_update_demo
+author: Codex
+version: 0.1.0
+license: MIT
+description: Example pipe that updates a chat title while running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from open_webui.models.chats import Chats
+
+
+class Pipe:
+    """Pipeline demonstrating manual chat title updates."""
+
+    async def pipe(
+        self,
+        body: Dict[str, Any],
+        __metadata__: Dict[str, Any],
+        __request__: Any,
+    ):
+        chat_id = __metadata__.get("chat_id")
+        if not chat_id:
+            yield "Missing chat_id"
+            return
+
+        config = __request__.app.state.config
+        old_setting = getattr(config, "ENABLE_TITLE_GENERATION", True)
+        config.ENABLE_TITLE_GENERATION = False
+        try:
+            Chats.update_chat_title_by_id(chat_id, "Processing...")
+            yield "starting"
+
+            await asyncio.sleep(0)
+
+            Chats.update_chat_title_by_id(chat_id, "Halfway done")
+            yield "halfway"
+
+            await asyncio.sleep(0)
+
+            final_title = f"Completed: {body['messages'][-1]['content']}"
+            Chats.update_chat_title_by_id(chat_id, final_title)
+            yield "done"
+        finally:
+            config.ENABLE_TITLE_GENERATION = old_setting


### PR DESCRIPTION
## Summary
- document how WebUI generates chat titles and how to trigger updates
- link new doc from the docs README
- explain programmatic chat title updates
- add dynamic title update demo pipe
- test the demo pipe

## Testing
- `nox -s lint tests`