### PR TITLE
Add progress title pipe and docs

### DIFF
--- a/functions/pipes/README.md
+++ b/functions/pipes/README.md
@@ -24,6 +24,9 @@ tool calls.  See `openai_responses_api_pipeline.py` for async helpers such as
 `stream_responses`, `get_responses`, `extract_response_text`, and
 `execute_responses_tool_calls`.
 
+For a minimalist demo that updates the chat title as a task progresses see
+`example_title_progress.py`.
+
 Additional valves for injecting the current date and user context are documented
 in `docs/instruction_injection_valves.md`.
 

--- a/functions/pipes/example_title_progress.py
+++ b/functions/pipes/example_title_progress.py
@@ -1,0 +1,41 @@
+"""
+title: Example Title Progress Pipe
+id: example_title_progress
+version: 0.1.0
+description: Update the chat title multiple times to show task progress.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator, Callable, Awaitable, Dict
+from fastapi import Request
+
+from open_webui.models.chats import Chats
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: Dict[str, Any],
+        __request__: Request,
+        __event_emitter__: Callable[[Dict[str, Any]], Awaitable[None]],
+        __metadata__: Dict[str, Any],
+        **_,
+    ) -> AsyncIterator[str]:
+        chat_id = __metadata__.get("chat_id")
+
+        # Ensure the background task doesn't override custom progress titles
+        body.setdefault("background_tasks", {})["title_generation"] = False
+
+        for step in range(1, 4):
+            title = f"Processing {step}/3"
+            Chats.update_chat_title_by_id(chat_id, title)
+            await __event_emitter__({"type": "chat:title", "data": title})
+            await asyncio.sleep(0.1)  # simulate work
+            yield f"Step {step} complete\n"
+
+        final_title = "Task Complete"
+        Chats.update_chat_title_by_id(chat_id, final_title)
+        await __event_emitter__({"type": "chat:title", "data": final_title})
+        yield "All done!"


### PR DESCRIPTION
## Summary
- document how to update chat titles repeatedly during long tasks
- point to new progress demo pipe from the pipes README
- add `example_title_progress` pipe as a simple progress indicator

## Testing
- `nox -s lint tests`