### PR TITLE
Fix function tool conversion

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -57,6 +57,21 @@ def test_transform_tools_for_responses_api_keeps_non_function(dummy_chat):
     assert tools == body_tools
 
 
+def test_transform_tools_for_responses_api_mixed(dummy_chat):
+    pipeline = _reload_pipeline()
+    body_tools = [
+        {"type": "web_search", "search_context_size": "medium"},
+        {
+            "type": "function",
+            "name": "calculator",
+            "description": "math",
+            "parameters": {"type": "object"},
+        },
+    ]
+    tools = pipeline.transform_tools_for_responses_api(body_tools)
+    assert tools == body_tools
+
+
 @pytest.mark.asyncio
 async def test_build_responses_payload(dummy_chat):
     pipeline = _reload_pipeline()

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -1002,7 +1002,7 @@ def transform_tools_for_responses_api(
         if not isinstance(tool, dict):
             continue
         tool_type = tool.get("type")
-        if tool_type == "function" or "function" in tool:
+        if tool_type == "function":
             function_spec = tool.get("function", tool)
             tools_responses_api_json.append(
                 {


### PR DESCRIPTION
## Summary
- fix `transform_tools_for_responses_api` so only function type tools are transformed
- test conversion when function tools are mixed with others

## Testing
- `nox -s lint tests`