### PR TITLE
refactor openai payload prep

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -263,7 +263,7 @@ async def test_build_params_includes_reasoning(dummy_chat):
         chat_id="chat1",
     )
     assert params["tool_choice"] == "auto"
-    assert params["max_output_tokens"] == 50
+    assert params["max_tokens"] == 50
     assert params["temperature"] == 0.4
     assert params["top_p"] == 0.9
     assert params["user"] == "me@example.com"


### PR DESCRIPTION
## Summary
- reuse request body when preparing payload
- drop unsupported `stream_options`
- adjust tests

## Testing
- `nox -s lint tests`