### PR TITLE
Fix typo in pipeline docstring

### DIFF
--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -190,7 +190,7 @@ class Pipe:
         STORE_RESPONSE: bool = Field(
             default=False,
             description=(
-                "Whether to store the generated model response (on OpenAI's side) for later debuging. Defaults to False."
+                "Whether to store the generated model response (on OpenAI's side) for later debugging. Defaults to False."
             ),
         )  # Read more: https://platform.openai.com/docs/api-reference/responses/create#responses-create-store
 


### PR DESCRIPTION
## Summary
- minor fix in openai_responses_api_pipeline documentation

## Testing
- `nox -s lint`
- `nox -s tests`