### PR TITLE
Update pipeline for Pydantic v2

### DIFF
--- a/.tests/test_pipeline.py
+++ b/.tests/test_pipeline.py
@@ -226,7 +226,7 @@ def test_apply_user_valve_overrides_sets_log_level(dummy_chat):
         def __init__(self, **vals):
             self._vals = vals
 
-        def model_dump(self, exclude_none=True):  # mimic pydantic v2 API
+        def model_dump(self, exclude_none=True):  # mimic BaseModel.model_dump
             return self._vals
 
     overrides = Dummy(CUSTOM_LOG_LEVEL="DEBUG")

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -5,7 +5,7 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 1.6.19
+version: 1.6.20
 license: MIT
 requirements: httpx
 
@@ -36,6 +36,7 @@ requirements: httpx
 ------------------------------------------------------------------------------
 🛠 CHANGE LOG
 ------------------------------------------------------------------------------
+• 1.6.20: Updated for Pydantic v2.
 • 1.6.19: Added support for 'o3-mini-high' and 'o4-mini-high' model aliases.
 • 1.6.18: Compatibility fixes for WebUI task models (optional chat_id and emitter).
 • 1.6.17: Valves to inject the current date and user/device context into the system prompt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
   "httpx",
   "fastapi",
-  "pydantic",
+  "pydantic>=2",
   "requests"
 ]
 


### PR DESCRIPTION
## Summary
- bump OpenAI Responses pipeline version
- note Pydantic v2 in changelog
- require `pydantic>=2` in pyproject
- remove outdated v2 reference in tests

## Testing
- `nox -s lint tests`