### PR TITLE
Improve event docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ This folder stores internal notes and planning documents for extensions. Files h
 
 - `pipe_input.md` – details the full structure of arguments passed to a pipe's `pipe()` method.
 - `chat_title.md` – explains how chat titles are generated and updated.
+- `events.md` – how to emit live UI events using `__event_emitter__` and `__event_call__`.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,48 @@
+# Events: `__event_emitter__` and `__event_call__`
+
+Open WebUI extensions can push real-time updates to the UI.  Each Tool or Pipe receives two async helpers:
+
+* `__event_emitter__` – fire-and-forget events
+* `__event_call__` – events that wait for user input
+
+Both helpers expect a dictionary `{"type": str, "data": dict}`.  `__event_call__` returns the user's response when applicable.
+
+## Common event types
+
+| type                | Purpose                                              |
+|---------------------|------------------------------------------------------|
+| `status`            | Progress or activity updates                          |
+| `chat:message:delta`| Append streamed text to the current message           |
+| `chat:message`      | Replace the current message content                   |
+| `chat:message:files`| Attach or update message files                        |
+| `chat:title`        | Update the conversation title                         |
+| `chat:tags`         | Update conversation tags                              |
+| `source`/`citation` | Add a citation or code execution result               |
+| `notification`      | Show a toast notification                             |
+| `confirmation`      | Ask for confirmation (requires `__event_call__`)      |
+| `input`             | Request simple user input (requires `__event_call__`) |
+| `execute`           | Run code client-side (requires `__event_call__`)      |
+
+Custom event types may be used if the frontend knows how to handle them.
+
+## Examples
+
+Emit a simple status update:
+
+```python
+await __event_emitter__({
+    "type": "status",
+    "data": {"description": "Processing started", "done": False}
+})
+```
+
+Pause execution until the user confirms:
+
+```python
+result = await __event_call__({
+    "type": "confirmation",
+    "data": {"title": "Are you sure?", "message": "Proceed with action?"}
+})
+```
+
+`result` will contain the user's answer or input value.

--- a/tools/README.md
+++ b/tools/README.md
@@ -212,17 +212,27 @@ Switch modes per chat: **Chat ⚙ Controls → Advanced Params → Function Call
 
 ## EventEmitter Patterns <a id="eventemitter-patterns"></a>
 
-If your method accepts `__event_emitter__`, you can push custom events:
+If your method accepts `__event_emitter__`, you can push custom events. The helper is asynchronous and expects a `{type, data}` payload:
 
 ```python
 async def download(self, url: str, __event_emitter__):
-    __event_emitter__("status", {"percent": 0})
+    await __event_emitter__({"type": "status", "data": {"percent": 0}})
     ...
-    __event_emitter__("status", {"percent": 100})
+    await __event_emitter__({"type": "status", "data": {"percent": 100}})
     return "Download complete!"
 ```
 
-Common event types: `status`, `message`, `notification`, `confirmation`.
+Need user interaction? Use `__event_call__`:
+
+```python
+result = await __event_call__({
+    "type": "confirmation",
+    "data": {"title": "Proceed?", "message": "Start download?"}
+})
+```
+
+Common event types include `status`, `chat:message:delta`, `chat:title`,
+`notification`, `confirmation`, `input`, and `execute`.
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to send events with `__event_emitter__` and `__event_call__`
- list the docs entry in `docs/README`
- fix example and event list in `tools/README`

## Testing
- `nox -s lint tests`