### PR TITLE
Fix Responses pipeline image handling

### DIFF
--- a/docs/file_storage.md
+++ b/docs/file_storage.md
@@ -61,3 +61,9 @@ python .scripts/publish_to_webui.py functions/pipes/my_pipe.py
 ```
 
 When your function needs to attach files it can emit a `chat:message:files` event with URLs returned by the Files API. The toolkit's `__event_emitter__` helper handles this for you.
+
+Image generation results from the OpenAI Responses API sometimes return a
+dictionary with a `url` or `b64_json` field.  The helper functions
+`open_webui.routers.images.load_url_image_data()` and
+`open_webui.routers.images.load_b64_image_data()` mirror WebUI's logic for
+converting these payloads to binary before uploading.


### PR DESCRIPTION
## Summary
- handle OpenAI responses where image result is a dict with a `url` or `b64_json`
- mention helper functions for converting image results in documentation

## Testing
- `nox -s lint tests`