### PR TITLE
Handle reasoning with details tags

### DIFF
--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -5,14 +5,14 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 1.6.23
+version: 1.6.24
 license: MIT
 requirements: httpx
 
 ------------------------------------------------------------------------------
 🚀 CURRENT FEATURES
 ------------------------------------------------------------------------------
-✅ o3/o4-mini o-series support (including visible <think> reasoning summaries)
+✅ o3/o4-mini o-series support (including visible reasoning summaries via <details> tags)
 ✅ Image Input: Directly upload images into conversations.
 ✅ Built-in Web Search: Enabled via Pipe valve (powered by OpenAI web_search tool)
 ✅ Usage Stats: passthrough (to OpenWebUI GUI)
@@ -36,6 +36,7 @@ requirements: httpx
 ------------------------------------------------------------------------------
 🛠 CHANGE LOG
 ------------------------------------------------------------------------------
+• 1.6.24: Reasoning placeholder now uses a closed <details> tag to render immediately.
 • 1.6.23: Fixed user valve merging when CUSTOM_LOG_LEVEL is set to 'INHERIT'.
 • 1.6.22: Added 'INHERIT' sentinel for CUSTOM_LOG_LEVEL.
 • 1.6.21: User valves trimmed to CUSTOM_LOG_LEVEL; legacy 'inherit' handled.
@@ -448,6 +449,8 @@ class Pipe:
         temp_input: list[dict[str, Any]] = []
         is_model_thinking = False
         last_image_url: str | None = None
+        reasoning_parts: list[str] = []
+        reasoning_start: float | None = None
 
         for loop_count in range(1, valves.MAX_TOOL_CALLS + 1):
             self.log.debug("Loop iteration #%d", loop_count)
@@ -479,11 +482,20 @@ class Pipe:
 
                 if request_params.get("reasoning") and not is_model_thinking:
                     is_model_thinking = True
+                    reasoning_start = time.monotonic()
+                    reasoning_parts = []
                     if __event_emitter__:
                         await __event_emitter__(
                             {
                                 "type": "chat:message:delta",
-                                "data": {"content": "<think>"},
+                                "data": {
+                                    "content": (
+                                        "<details type=\"reasoning\" "
+                                        "done=\"false\">"
+                                        "<summary>Thinking…</summary>"
+                                        "</details>\n"
+                                    )
+                                },
                             }
                         )
 
@@ -513,37 +525,43 @@ class Pipe:
                         self.log.error("Stream ended with event: %s", et)
                         break
                     if et == "response.reasoning_summary_part.added":
-                        # The <think> tag is emitted at stream start when
-                        # reasoning is enabled. No action needed here.
+                        # The thinking placeholder was already emitted at start.
                         continue
                     if et == "response.reasoning_summary_text.delta":
-                        if __event_emitter__:
-                            await __event_emitter__(
-                                {
-                                    "type": "chat:message:delta",
-                                    "data": {"content": event.get("delta")},
-                                }
-                            )
+                        reasoning_parts.append(event.get("delta", ""))
                         continue
                     if et == "response.reasoning_summary_text.done":
-                        if __event_emitter__:
-                            await __event_emitter__(
-                                {
-                                    "type": "chat:message:delta",
-                                    "data": {"content": "\n\n---\n\n"},
-                                }
-                            )
                         continue
                     if et == "response.content_part.added":
                         if is_model_thinking:
                             is_model_thinking = False
+                            reasoning_duration = (
+                                int(time.monotonic() - reasoning_start)
+                                if reasoning_start is not None
+                                else 0
+                            )
+                            reasoning_text = "".join(reasoning_parts)
+                            reasoning_display = "\n".join(
+                                (
+                                    f"> {line}" if not line.startswith(">") else line
+                                )
+                                for line in reasoning_text.splitlines()
+                            )
                             if __event_emitter__:
                                 await __event_emitter__(
                                     {
                                         "type": "chat:message:delta",
-                                        "data": {"content": "</think>\n"},
+                                        "data": {
+                                            "content": (
+                                                f"<details type=\"reasoning\" done=\"true\" duration=\"{reasoning_duration}\">\n"
+                                                f"<summary>Thought for {reasoning_duration} seconds</summary>\n"
+                                                f"{reasoning_display}\n"
+                                                "</details>\n\n---\n\n"
+                                            )
+                                        },
                                     }
                                 )
+                            reasoning_parts = []
 
                         continue
                     if et == "response.output_text.delta":


### PR DESCRIPTION
## Summary
- emit closed `<details type="reasoning">` placeholder in `openai_responses_api_pipeline`
- send final reasoning summary block when content appears
- document change in changelog

## Testing
- `nox -s lint tests`