### PR TITLE
Clarify DB behavior for `replace` events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -48,7 +48,7 @@ the message already exists. `message` events fetch the stored message (if any),
 append the new chunk, and then call
 `Chats.upsert_message_to_chat_by_id_and_message_id` to save the result. If no
 message exists the update is skipped. `replace` overwrites the current text with
-the provided content. Event types like `chat:completion` are
+the provided content or creates the message if it doesn't already exist. Event types like `chat:completion` are
 transient unless you persist them explicitly. When using the standard pipeline
 this save happens automatically after the final chunk. If you emit
 `chat:completion` events yourself, call `Chats.upsert_message_to_chat_by_id_and_message_id`


### PR DESCRIPTION
## Summary
- note that `replace` events also create a message when missing

## Testing
- `nox -s lint tests`