### PR TITLE
Improve events docs and add metadata persistence example

### DIFF
--- a/.tests/test_metadata_persistence.py
+++ b/.tests/test_metadata_persistence.py
@@ -1,0 +1,45 @@
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+def _load_pipe():
+    path = Path(__file__).resolve().parents[1] / "functions" / "pipes" / "example_metadata_persistence.py"
+    spec = spec_from_file_location("example_metadata_persistence", path)
+    mod = module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.Pipe
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_persists_across_turns(dummy_chat):
+    Pipe = _load_pipe()
+    pipe = Pipe()
+    from open_webui.models.chats import Chats
+    chat_id = "chat1"
+
+    # First turn
+    body1 = {"messages": [{"id": "u1", "role": "user", "content": "hi"}]}
+    metadata1 = {"chat_id": chat_id, "message_id": "m1"}
+    out1 = [chunk async for chunk in pipe.pipe(body1, metadata1)]
+    assert out1 == ["No previous meta\n", "Echo: hi"]
+    msg1 = Chats.get_message_by_id_and_message_id(chat_id, "m1")
+    assert msg1["custom_meta"] == "stored:hi"
+    # Simulate final content save
+    Chats.upsert_message_to_chat_by_id_and_message_id(chat_id, "m1", {"content": "Echo: hi"})
+
+    # Second turn
+    body2 = {
+        "messages": [
+            {"id": "u1", "role": "user", "content": "hi"},
+            {"id": "m1", "role": "assistant", "content": "Echo: hi"},
+            {"id": "u2", "role": "user", "content": "again"},
+        ]
+    }
+    metadata2 = {"chat_id": chat_id, "message_id": "m2"}
+    out2 = [chunk async for chunk in pipe.pipe(body2, metadata2)]
+    assert out2[0] == "Previous meta: stored:hi\n"
+    msg2 = Chats.get_message_by_id_and_message_id(chat_id, "m2")
+    assert msg2["custom_meta"] == "stored:again"

--- a/docs/events.md
+++ b/docs/events.md
@@ -93,6 +93,16 @@ Chats.upsert_message_to_chat_by_id_and_message_id(chat_id, message_id, {"content
 ```
 【F:external/open-webui/backend/open_webui/models/chats.py†L228-L249】
 
+### Custom metadata persistence
+
+`Chats.upsert_message_to_chat_by_id_and_message_id` merges the provided
+dictionary with any existing message data. Fields not mentioned remain
+untouched, so you can store additional keys for your own use. Later
+updates from the pipeline—such as the final `chat:completion` write—only
+replace the built-in fields like `content` and preserve everything else.
+This allows pipes to attach hidden state to a message and read it back in
+subsequent turns.
+
 ## Common event types
 
 | type                | Purpose                                              |

--- a/functions/pipes/example_metadata_persistence.py
+++ b/functions/pipes/example_metadata_persistence.py
@@ -1,0 +1,44 @@
+"""
+ title: Example Metadata Persistence
+ id: example_metadata_persistence
+ version: 0.1.0
+ description: Demonstrates storing custom metadata in chat history and reading it back on the next turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict
+
+from open_webui.models.chats import Chats
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: Dict[str, Any],
+        __metadata__: Dict[str, Any],
+        **_,
+    ) -> AsyncIterator[str]:
+        chat_id = __metadata__.get("chat_id")
+        message_id = __metadata__.get("message_id")
+
+        messages = body.get("messages", [])
+        prev_meta = None
+        if len(messages) >= 2:
+            prev_msg_id = messages[-2].get("id")
+            if prev_msg_id:
+                prev = Chats.get_message_by_id_and_message_id(chat_id, prev_msg_id)
+                prev_meta = prev.get("custom_meta")
+
+        if prev_meta:
+            yield f"Previous meta: {prev_meta}\n"
+        else:
+            yield "No previous meta\n"
+
+        user_text = messages[-1].get("content", "")
+        Chats.upsert_message_to_chat_by_id_and_message_id(
+            chat_id,
+            message_id,
+            {"custom_meta": f"stored:{user_text}"},
+        )
+        yield f"Echo: {user_text}"


### PR DESCRIPTION
## Summary
- clarify that custom metadata is preserved when messages are saved
- add example pipe storing custom metadata across turns
- test persistence with new pipe

## Testing
- `nox -s lint tests`