### PR TITLE
Improve events docs and metadata example

### DIFF
--- a/.tests/test_metadata_persistence.py
+++ b/.tests/test_metadata_persistence.py
@@ -1,0 +1,47 @@
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+def _load_pipe():
+    path = Path(__file__).resolve().parents[1] / "functions" / "pipes" / "example_metadata_persistence.py"
+    spec = spec_from_file_location("example_metadata_persistence", path)
+    mod = module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod.Pipe
+
+
+@pytest.mark.asyncio
+async def test_custom_metadata_persists_across_turns(dummy_chat):
+    Pipe = _load_pipe()
+    pipe = Pipe()
+    from open_webui.models.chats import Chats
+    chat_id = "chat1"
+
+    # First turn
+    body1 = {"messages": [{"role": "user", "content": "hi"}]}
+    metadata1 = {"chat_id": chat_id, "message_id": "m1"}
+    out1 = [chunk async for chunk in pipe.pipe(body1, metadata1)]
+    assert out1 == ["No previous meta\n", "Echo: hi"]
+    msg1 = Chats.get_message_by_id_and_message_id(chat_id, "m1")
+    assert msg1["custom_meta"] == "stored:hi"
+    # Simulate final content save
+    Chats.upsert_message_to_chat_by_id_and_message_id(
+        chat_id, "m1", {"content": "Echo: hi", "role": "assistant"}
+    )
+
+    # Second turn
+    body2 = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Echo: hi"},
+            {"role": "user", "content": "again"},
+        ]
+    }
+    metadata2 = {"chat_id": chat_id, "message_id": "m2"}
+    out2 = [chunk async for chunk in pipe.pipe(body2, metadata2)]
+    assert out2[0] == "Previous meta: stored:hi\n"
+    msg2 = Chats.get_message_by_id_and_message_id(chat_id, "m2")
+    assert msg2["custom_meta"] == "stored:again"

--- a/functions/pipes/example_metadata_persistence.py
+++ b/functions/pipes/example_metadata_persistence.py
@@ -1,0 +1,52 @@
+"""
+ title: Example Metadata Persistence
+ id: example_metadata_persistence
+ version: 0.1.0
+ description: Demonstrates storing custom metadata in chat history and reading it back on the next turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict
+
+from open_webui.utils.misc import get_message_list
+
+from open_webui.models.chats import Chats
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: Dict[str, Any],
+        __metadata__: Dict[str, Any],
+        **_,
+    ) -> AsyncIterator[str]:
+        chat_id = __metadata__.get("chat_id")
+        message_id = __metadata__.get("message_id")
+
+        messages = body.get("messages", [])
+        prev_meta = None
+        chat = Chats.get_chat_by_id(chat_id)
+        if chat:
+            history = chat.chat.get("history", {})
+            messages_lookup = history.get("messages", {})
+            chain = get_message_list(messages_lookup, history.get("currentId")) or []
+            if chain:
+                # Skip the incoming user message at the end
+                for msg in reversed(chain[:-1]):
+                    if msg.get("role") == "assistant":
+                        prev_meta = msg.get("custom_meta")
+                        break
+
+        if prev_meta:
+            yield f"Previous meta: {prev_meta}\n"
+        else:
+            yield "No previous meta\n"
+
+        user_text = messages[-1].get("content", "")
+        Chats.upsert_message_to_chat_by_id_and_message_id(
+            chat_id,
+            message_id,
+            {"custom_meta": f"stored:{user_text}"},
+        )
+        yield f"Echo: {user_text}"


### PR DESCRIPTION
## Summary
- clarify how to read metadata from chat history when message IDs aren't present
- update example pipe to fetch previous metadata from the database
- adjust metadata persistence test accordingly

## Testing
- `nox -s lint tests`