### PR TITLE
Update events persistence docs

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -71,11 +71,17 @@ the message already exists. `message` events fetch the stored message (if any),
 append the new chunk, and then call
 `Chats.upsert_message_to_chat_by_id_and_message_id` to save the result. If no
 message exists the update is skipped. `replace` overwrites the current text with
-the provided content or creates the message if it doesn't already exist. Event types like `chat:completion` are
-transient unless you persist them explicitly. When using the standard pipeline
-this save happens automatically after the final chunk. If you emit
-`chat:completion` events yourself, call `Chats.upsert_message_to_chat_by_id_and_message_id`
-when you're done.
+the provided content or creates the message if it doesn't already exist. The
+helper also updates `history.currentId` and the chat's `updated_at` timestamp
+each time a message is persisted.
+
+Event types like `chat:completion` are transient unless you persist them
+explicitly. When using the standard pipeline this save happens automatically,
+but the frequency depends on the `ENABLE_REALTIME_CHAT_SAVE` environment
+variable. When enabled the pipeline saves after each streamed chunk; otherwise
+(the default) it writes only once at the end. If you emit `chat:completion`
+events yourself, call `Chats.upsert_message_to_chat_by_id_and_message_id` when
+you're done.
 
 To emit without touching the database pass `False` when retrieving the emitter:
 


### PR DESCRIPTION
## Summary
- document chat event database behaviour
- clarify how realtime saves work with `ENABLE_REALTIME_CHAT_SAVE`

## Testing
- `nox -s lint tests`