### PR TITLE
Add async pipeline unit tests

### DIFF
--- a/.tests/conftest.py
+++ b/.tests/conftest.py
@@ -1,0 +1,52 @@
+import sys
+import types
+
+# Create stubs for open_webui modules used by the pipeline
+open_webui = types.ModuleType("open_webui")
+models_mod = types.ModuleType("open_webui.models")
+chats_mod = types.ModuleType("open_webui.models.chats")
+
+class Chats:
+    @staticmethod
+    def get_chat_by_id(chat_id):
+        return None
+
+chats_mod.Chats = Chats
+
+models_models_mod = types.ModuleType("open_webui.models.models")
+class Models:
+    @staticmethod
+    def get_model_by_id(model_id):
+        return None
+
+    @staticmethod
+    def update_model_by_id(model_id, model_form):
+        return False
+
+class ModelForm:
+    def __init__(self, **kwargs):
+        pass
+
+class ModelParams:
+    def __init__(self, **kwargs):
+        pass
+
+models_models_mod.Models = Models
+models_models_mod.ModelForm = ModelForm
+models_models_mod.ModelParams = ModelParams
+
+utils_mod = types.ModuleType("open_webui.utils")
+misc_mod = types.ModuleType("open_webui.utils.misc")
+
+def get_message_list(*args, **kwargs):
+    return []
+
+misc_mod.get_message_list = get_message_list
+utils_mod.misc = misc_mod
+
+sys.modules.setdefault("open_webui", open_webui)
+sys.modules.setdefault("open_webui.models", models_mod)
+sys.modules.setdefault("open_webui.models.chats", chats_mod)
+sys.modules.setdefault("open_webui.models.models", models_models_mod)
+sys.modules.setdefault("open_webui.utils", utils_mod)
+sys.modules.setdefault("open_webui.utils.misc", misc_mod)

--- a/.tests/test_openai_pipeline.py
+++ b/.tests/test_openai_pipeline.py
@@ -1,0 +1,138 @@
+import json
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from functions.pipes.openai_responses_api_pipeline import (
+    Pipe,
+    execute_responses_tool_calls,
+    parse_responses_sse,
+    sanitize_for_log,
+    simplify_user_agent,
+    stream_responses,
+    transform_tools_for_responses_api,
+)
+
+
+def test_sanitize_for_log():
+    data = {
+        "profile_image_url": "http://example.com/pic.png",
+        "files": [
+            {
+                "id": "1",
+                "name": "orig.txt",
+                "size": 10,
+                "file": {"filename": "ignored.txt", "meta": {"size": 20}},
+            }
+        ],
+        "data": {"content": "secret"},
+        "nested": [{"profile_image_url": "foo"}],
+    }
+    out = sanitize_for_log(data)
+    assert out["profile_image_url"] == "<profile_image_url>"
+    assert out["files"] == [{"id": "1", "name": "orig.txt", "size": 10}]
+    assert out["data"] == {"content": "<content>"}
+    assert out["nested"][0]["profile_image_url"] == "<profile_image_url>"
+
+
+def test_simplify_user_agent():
+    chrome = (
+        "Mozilla/5.0 (X11; Linux x86_64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0 Safari/537.36"
+    )
+    assert simplify_user_agent(chrome) == "Chrome 123"
+    assert simplify_user_agent("") == "Unknown"
+    assert simplify_user_agent("FooBar/1.0") == "FooBar/1.0".split()[0]
+
+
+def test_parse_responses_sse():
+    data = json.dumps({"foo": 1})
+    result = parse_responses_sse("delta", data)
+    assert result == {"foo": 1, "type": "delta"}
+
+    result = parse_responses_sse("delta", json.dumps({"type": "other"}))
+    assert result == {"type": "other"}
+
+    result = parse_responses_sse(None, json.dumps({"bar": 2}))
+    assert result == {"bar": 2, "type": "message"}
+
+
+def test_transform_tools_for_responses_api():
+    tools = [
+        {"type": "function", "function": {"name": "hello"}},
+        {"type": "web_search", "web_search": {"search_context_size": "high"}},
+        {"type": "noop"},
+        {"other": 1},
+    ]
+    out = transform_tools_for_responses_api(tools)
+    assert out[0] == {"type": "function", "name": "hello"}
+    assert out[1] == {"type": "web_search", "search_context_size": "high"}
+    assert out[2] == {"type": "noop"}
+    assert out[3] == {"other": 1}
+
+
+def test_update_usage():
+    pipe = Pipe()
+    total: dict[str, int] = {}
+    pipe._update_usage(total, {"input_tokens": 5}, 1)
+    assert total == {"input_tokens": 5, "loops": 1}
+    pipe._update_usage(total, {"input_tokens": 3, "details": {"a": 1}}, 2)
+    assert total["input_tokens"] == 8
+    assert total["details"] == {"a": 1}
+    assert total["loops"] == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_responses_tool_calls():
+    async def a_tool(x: int) -> int:
+        return x * 2
+
+    def b_tool(y: int) -> int:
+        return y + 1
+
+    registry = {
+        "a": {"callable": a_tool},
+        "b": {"callable": b_tool},
+    }
+    calls = [
+        SimpleNamespace(name="a", arguments=json.dumps({"x": 2})),
+        SimpleNamespace(name="b", arguments=json.dumps({"y": 3})),
+        SimpleNamespace(name="missing", arguments="{}"),
+    ]
+    result = await execute_responses_tool_calls(calls, registry)
+    assert result == [4, 4, "Tool not found"]
+
+
+@pytest.mark.asyncio
+async def test_stream_responses():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        content = (
+            b"event: delta\n"
+            b'data: {"foo": 1}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        return httpx.Response(200, content=content)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gen = stream_responses(client, "https://api", "KEY", {"model": "gpt"})
+    events = [event async for event in gen]
+    await client.aclose()
+    assert events == [{"foo": 1, "type": "delta"}]
+
+
+def test_info_suffix_helpers():
+    pipe = Pipe()
+    user = {"name": "Jane", "email": "jane@example.com"}
+    assert pipe._get_user_info_suffix(user) == "user_info: Jane <jane@example.com>"
+
+    request = types.SimpleNamespace(
+        headers={
+            "sec-ch-ua-mobile": "?1",
+            "sec-ch-ua-platform": '"Linux"',
+            "user-agent": "Mozilla/5.0 Chrome/123.0 Safari/537.36",
+        }
+    )
+    expected = "browser_info: Mobile | Linux | Browser: Chrome 123"
+    assert pipe._get_browser_info_suffix(request) == expected

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -407,7 +407,6 @@ class Pipe:
         cleanup_ids: list[str] = []
         temp_input: list[dict[str, Any]] = []
         is_model_thinking = False
-        last_image_url: str | None = None
 
         for loop_count in range(1, valves.MAX_TOOL_CALLS + 1):
             self.log.debug("Loop iteration #%d", loop_count)
@@ -586,16 +585,18 @@ class Pipe:
                         ):
                             #TODO IMPLEMENT LOGIC FOR UPLOADING IMAGE TO FILES AND EMITTING IT
                            if __event_emitter__:
-                               await __event_emitter__(
-                                   {
-                                       "type": "chat:message:files",
-                                       "data": {
-                                           "file.s": [
-                                               {"type": "image", "url": url}
-                                           ]
-                                       },
-                                   }
-                               )
+                               image_url = item.get("url")
+                               if image_url:
+                                   await __event_emitter__(
+                                       {
+                                           "type": "chat:message:files",
+                                           "data": {
+                                               "file.s": [
+                                                   {"type": "image", "url": image_url}
+                                               ]
+                                           },
+                                       }
+                                   )
                                await self._emit_status(
                                    __event_emitter__,
                                    "🖼️ Image generation completed",


### PR DESCRIPTION
## Summary
- add pytest stubs for `open_webui` modules so tests run without upstream project
- write unit tests covering helper functions in `openai_responses_api_pipeline.py`
- fix lint issues in pipeline

## Testing
- `nox -s lint tests`