### PR TITLE
Fix debug handler init order

### DIFF
--- a/.tests/test_openai_pipeline.py
+++ b/.tests/test_openai_pipeline.py
@@ -2,6 +2,8 @@ import json
 import types
 from types import SimpleNamespace
 
+import logging
+
 import httpx
 import pytest
 
@@ -136,3 +138,16 @@ def test_info_suffix_helpers():
     )
     expected = "browser_info: Mobile | Linux | Browser: Chrome 123"
     assert pipe._get_browser_info_suffix(request) == expected
+
+
+def test_user_valve_log_level_override():
+    pipe = Pipe()
+    assert pipe.log.level == logging.INFO
+
+    valves = Pipe.UserValves(CUSTOM_LOG_LEVEL="DEBUG")
+    pipe._apply_user_valve_overrides(valves)
+
+    assert pipe.log.level == logging.DEBUG
+    handler, _ = pipe._attach_debug_handler()
+    assert handler is not None
+    pipe._detach_debug_handler(handler)

--- a/functions/pipes/openai_responses_api_pipeline.py
+++ b/functions/pipes/openai_responses_api_pipeline.py
@@ -369,8 +369,8 @@ class Pipe:
         """
         start_ns = time.perf_counter_ns()
         last_status: list[tuple[str, bool] | None] = [None]
-        mem_handler, debug_logs = self._attach_debug_handler()
         valves = self._apply_user_valve_overrides(__user__.get("valves"))
+        mem_handler, debug_logs = self._attach_debug_handler()
         self._debug_block(
             "pipe_call",
             {


### PR DESCRIPTION
## Summary
- apply user valve overrides before attaching the debug handler
- test log level override behavior

## Testing
- `nox -s lint tests`