### PR TITLE
Fix image generation files emitter key

### DIFF
--- a/functions/pipes/openai_responses_pipeline.py
+++ b/functions/pipes/openai_responses_pipeline.py
@@ -573,7 +573,7 @@ class Pipe:
                                         {
                                             "type": "chat:message:files",
                                             "data": {
-                                                "file.s": [
+                                                "files": [
                                                     {"type": "image", "url": image_url}
                                                 ]
                                             },


### PR DESCRIPTION
## Summary
- correct typo when emitting generated image

## Testing
- `pytest -q`
