### PR TITLE
Ensure OpenAI responses are persisted

### DIFF
--- a/functions/pipes/openai_responses_pipeline.py
+++ b/functions/pipes/openai_responses_pipeline.py
@@ -758,6 +758,13 @@ class Pipe:
                     }
                 )
 
+            if chat_id and message_id:
+                Chats.upsert_message_to_chat_by_id_and_message_id(
+                    chat_id,
+                    message_id,
+                    {"role": "assistant", "content": message_content},
+                )
+
             if last_response_id and not valves.STORE_RESPONSE:
                 try:
                     await delete_response(


### PR DESCRIPTION
## Summary
- store assistant replies using `Chats.upsert_message_to_chat_by_id_and_message_id`
  to persist the final text even when the client disconnects

## Testing
- `ruff check functions/pipes/openai_responses_pipeline.py`
- `pytest -q`
