### PR TITLE
Refine per-request log level filter

### DIFF
--- a/docs/pipe_input.md
+++ b/docs/pipe_input.md
@@ -83,6 +83,8 @@ Example:
 
 If omitted, `CUSTOM_LOG_LEVEL` defaults to the sentinel value `INHERIT`.  Any
 field set to `INHERIT` is ignored, so the pipe's configured log level is used.
+The selected level applies only to that request because the pipeline tracks the
+active log level using a `ContextVar`.
 
 ## 3. `__request__`
 

--- a/functions/pipes/openai_responses_pipeline.py
+++ b/functions/pipes/openai_responses_pipeline.py
@@ -47,6 +47,9 @@ FEATURE_SUPPORT = {
 # A global context var storing the current message ID
 current_message_id = ContextVar("current_message_id", default=None)
 
+# Log level ContextVar (defaults to INFO)
+current_log_level = ContextVar("current_log_level", default=logging.INFO)
+
 # In-memory logs keyed by message ID
 logs_by_msg_id = defaultdict(list)
 
@@ -160,19 +163,26 @@ class Pipe:
         self.log = logging.getLogger(__name__)
         # Prevent propagation to the root logger which may add its own handlers
         self.log.propagate = False
-        self.log.setLevel(logging.INFO)
+        # Set to DEBUG so per-message filtering controls output
+        self.log.setLevel(logging.DEBUG)
 
-        # Add an inline “filter” that injects `message_id` into each record
+        # Add an inline "filter" that injects `message_id` into each record
         self.log.addFilter(
             lambda record: (
                 setattr(
                     record,
                     "message_id",
-                    getattr(record, "message_id", None) or current_message_id.get()
+                    getattr(record, "message_id", None) or current_message_id.get(),
                 )
                 or True
             )
         )
+
+        # Filter logs based on the ContextVar-controlled log level
+        def _per_message_level(record, logger=self.log):
+            return record.levelno >= current_log_level.get(logger.level)
+
+        self.log.addFilter(_per_message_level)
 
         console = logging.StreamHandler(sys.stdout)
         console.setFormatter(logging.Formatter(
@@ -197,9 +207,6 @@ class Pipe:
         self.log.addHandler(mem_handler)
     
     def pipes(self):
-        # Update logging level (handy trick since valve values are accessible here)
-        self.log.setLevel(getattr(logging, self.valves.CUSTOM_LOG_LEVEL.upper(), logging.INFO))
-
         # return list of models to expose in Open WebUI
         models = [m.strip() for m in self.valves.MODEL_ID.split(",") if m.strip()]
         return [{"id": model, "name": f"OpenAI: {model}", "direct": True} for model in models]
@@ -228,9 +235,10 @@ class Pipe:
         user_valves = self.UserValves.model_validate(__user__.get("valves", {}))
         valves = self._merge_valves(self.valves, user_valves)
 
-        # update log level
-        # TODO Right now, this effective all users logs.  Need to find a way to set per-user log level.
-        self.log.setLevel(getattr(logging, valves.CUSTOM_LOG_LEVEL.upper(), logging.INFO))
+        # Update per-message log level via ContextVar
+        log_token = current_log_level.set(
+            getattr(logging, valves.CUSTOM_LOG_LEVEL.upper(), logging.INFO)
+        )
 
         try:
             self.log.info("In pipe, get() returns: %s", extra={"message_id": message_id})
@@ -403,6 +411,7 @@ class Pipe:
                 )
 
             current_message_id.reset(token)
+            current_log_level.reset(log_token)
             logs_by_msg_id.pop(message_id, None)
 
             if __metadata__.get("task") is None:


### PR DESCRIPTION
## Summary
- always enable DEBUG logs internally to allow per-request filtering
- remove global log level change in `pipes()`

## Testing
- `ruff check functions/pipes/openai_responses_pipeline.py`
- `pytest -q` *(no tests ran)*


------
https://chatgpt.com/codex/tasks/task_e_683b5286ed24832e8d0cdc026dafad86