### PR TITLE
Improve docs clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of **pipes**, **filters** and **tools** for extending [Open WebUI](
 - `functions/pipes/` – self‑contained pipes
 - `functions/filters/` – reusable filters
 - `tools/` – standalone tools
-- `docs/` – notes about WebUI internals (useful for thoses creating their own filters / pipes / tools).
+- `docs/` – notes about WebUI internals (useful for those creating their own filters, pipes or tools).
 
 Each subdirectory has a small README explaining its contents.
 
@@ -17,11 +17,11 @@ This repo uses three long‑lived branches:
 
 1. **`development`** – active development and experiments; may break.
 2. **`alpha-preview`** – next release candidate. More stable than `development`.
-3. **`main`** – production‑ready code pulled from `beta`.
+3. **`main`** – production‑ready code pulled from `alpha-preview`.
 
 Feature work typically happens in short‑lived branches, merged into `development` via pull requests.
 
-Changes flow from `dev` → `alpha-preview` → and finally `main` after testing.
+Changes flow from `development` → `alpha-preview` → `main` after testing.
 
 ## Installing Toolkit Locally (for developers)
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,6 @@
 This folder stores internal notes and planning documents for extensions. Files here are not part of the runtime package.
 
 - `pipe_input.md` – details the full structure of arguments passed to a pipe's `pipe()` method.
-- `chat_title.md` – explains how chat titles are generated and updated.
+- `chat_title.md` – *(coming soon)* how chat titles are generated and updated.
 - `events.md` – how to emit live UI events using `__event_emitter__` and `__event_call__`.
 - `file_storage.md` – where uploaded files and generated images are kept and how to attach them to chats.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,7 +1,7 @@
 # Events: `__event_emitter__` and `__event_call__`
 
-Open WebUI extensions can push real-time updates to the UI. Each Tool or Pipe
-receives two async helpers:
+Open WebUI extensions can push real-time updates to the UI. Every tool or pipe
+receives two asynchronous helpers:
 
 * `__event_emitter__` – fire-and-forget events
 * `__event_call__` – events that wait for user input and return the user's


### PR DESCRIPTION
## Summary
- fix typos in the main README
- clarify docs README
- tweak wording in the events guide

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_683b8c1d94bc832ebf1afb67b80d8ff3