### PR TITLE
Add status & notification emitters

### DIFF
--- a/functions/pipes/OpenAI Responses Manifold/openai_responses_manifold.py
+++ b/functions/pipes/OpenAI Responses Manifold/openai_responses_manifold.py
@@ -716,6 +716,40 @@ class Pipe:
 
         await event_emitter({"type": "chat:completion", "data": data, "done": done})
 
+    async def _emit_status(
+        self,
+        event_emitter: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        description: str,
+        *,
+        done: bool = False,
+        hidden: bool = False,
+    ) -> None:
+        """Emit a status event to the UI if possible."""
+        if event_emitter is None:
+            return
+
+        await event_emitter(
+            {
+                "type": "status",
+                "data": {"description": description, "done": done, "hidden": hidden},
+            }
+        )
+
+    async def _emit_notification(
+        self,
+        event_emitter: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        content: str,
+        *,
+        level: Literal["info", "success", "warning", "error"] = "info",
+    ) -> None:
+        """Emit a toast notification event to the UI if possible."""
+        if event_emitter is None:
+            return
+
+        await event_emitter(
+            {"type": "notification", "data": {"type": level, "content": content}}
+        )
+
     def _merge_valves(self, global_valves, user_valves) -> "Pipe.Valves":
         """
         Merge user-level valves into default.


### PR DESCRIPTION
## Summary
- add `_emit_status` and `_emit_notification` helpers

## Testing
- `ruff check functions tools .tests .scripts`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683bdb055838832e935f0120896e271e