### PR TITLE
Strip <details> blocks from assistant history

### DIFF
--- a/.tests/test_openai_responses_manifold.py
+++ b/.tests/test_openai_responses_manifold.py
@@ -7,5 +7,5 @@ except ModuleNotFoundError:  # pragma: no cover - not packaged during tests
     sys.modules["orjson"] = object()
 
 def test_importable():
-    mod = import_module('functions.pipes.OpenAI Responses Manifold.openai_responses_manifold')
+    mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
     assert hasattr(mod, 'Pipe')


### PR DESCRIPTION
## Summary
- remove `<details>` blocks from assistant messages when reconstructing history
- tweak failing test import path

## Testing
- `ruff check functions tools .tests .scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d068fb37c832eb4f1566c21637972