### PR TITLE
Bind reasoning tokens to generating model

### DIFF
--- a/.tests/test_openai_responses_manifold.py
+++ b/.tests/test_openai_responses_manifold.py
@@ -9,3 +9,44 @@ except ModuleNotFoundError:  # pragma: no cover - not packaged during tests
 def test_importable():
     mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
     assert hasattr(mod, 'Pipe')
+
+
+def test_history_filters_by_model(monkeypatch):
+    mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
+    ChatModel = import_module('open_webui.models.chats').ChatModel
+
+    # Patch get_message_list to return the requested message only
+    monkeypatch.setattr(mod, "get_message_list", lambda hist, mid: [hist[mid]])
+
+    chat = {
+        "history": {
+            "currentId": "msg1",
+            "messages": {
+                "msg1": {
+                    "id": "msg1",
+                    "role": "user",
+                    "content": "hello",
+                    "parentId": None,
+                    "childrenIds": [],
+                }
+            },
+        },
+        "openai_responses_pipe": {
+            "messages": {
+                "msg1": [
+                    {"type": "reasoning", "encrypted_content": "A", "model": "x"},
+                    {"type": "reasoning", "encrypted_content": "B", "model": "y"},
+                ]
+            }
+        },
+    }
+
+    monkeypatch.setattr(mod.Chats, "get_chat_by_id", lambda cid: ChatModel(chat) if cid == "c" else None)
+
+    res_x = mod.build_responses_history_by_chat_id_and_message_id("c", "msg1", model_id="x")
+    assert any(item.get("encrypted_content") == "A" for item in res_x)
+    assert all(item.get("encrypted_content") != "B" for item in res_x)
+
+    res_y = mod.build_responses_history_by_chat_id_and_message_id("c", "msg1", model_id="y")
+    assert any(item.get("encrypted_content") == "B" for item in res_y)
+    assert all(item.get("encrypted_content") != "A" for item in res_y)

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -31,3 +31,10 @@ The pipe exposes multiple valves to tweak behaviour. The most common ones are:
 - `LOG_LEVEL` – Control per‑message logging level.
 
 See the source file for the full list of valves and defaults.
+
+### Stored response items
+
+When the pipe persists tool calls or reasoning output it writes them under
+`chat.openai_responses_pipe.messages[<message_id>]`. Each stored item now also
+records the model that produced it so history reconstruction can skip
+incompatible data when switching models.


### PR DESCRIPTION
## Summary
- tag stored OpenAI response items with their generating model
- filter stored items by model when reconstructing chat history
- document model field on stored response items

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d3b95a140832eb73ba5dbb74d4588