### PR TITLE
Add AGENTS and CHANGELOG for responses manifold

### DIFF
--- a/functions/pipes/openai_responses_manifold/AGENTS.md
+++ b/functions/pipes/openai_responses_manifold/AGENTS.md
@@ -1,0 +1,20 @@
+# Pipeline Instructions for OpenAI Responses Manifold
+
+This guide applies to all files in this directory.
+
+## Versioning
+
+`openai_responses_manifold.py` contains a `version:` field in its top level docstring.
+We follow **Semantic Versioning** (`MAJOR.MINOR.PATCH`):
+
+- **MAJOR** – incompatible or breaking changes.
+- **MINOR** – backward compatible feature additions.
+- **PATCH** – bug fixes or internal changes that keep existing behaviour.
+
+## Changelog Updates
+
+Whenever `openai_responses_manifold.py` is modified, increment the version field
+following the rules above **and** add an entry to `CHANGELOG.md` under a new
+heading `## [x.y.z] - YYYY-MM-DD` describing the change.
+
+Documentation-only edits do not require a version bump.

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the OpenAI Responses Manifold pipeline are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.7.0] - 2025-06-01
+- Initial version imported into the toolkit.


### PR DESCRIPTION
## Summary
- document rules for versioning and changelog entries in `AGENTS.md`
- start `CHANGELOG.md` for the OpenAI Responses Manifold pipe

## Testing
- `nox -s lint tests`

------
https://chatgpt.com/codex/tasks/task_e_683e3687aca4832e8af9b07bf45becf5