### PR TITLE
Enable native tool calling automatically

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2025-06-04
+- Always enable native tool calling for supported models.
+- Removed `ENABLE_NATIVE_TOOL_CALLING` valve.
+- Simplified native function setup.
+
 ## [0.7.0] - 2025-06-02
 - Downgraded major version to `0` to indicate pre-production early testing stage.
 - Fixed finalization logic so streamed responses always close correctly.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -10,7 +10,7 @@
 ## Features
 | Feature | Status | Last updated | Notes |
 | --- | --- | --- | --- |
-| Native function calling | ✅ GA | 2025-06-03 | Toggle via `ENABLE_NATIVE_TOOL_CALLING`. |
+| Native function calling | ✅ GA | 2025-06-04 | Automatically enabled for supported models. |
 | Visible reasoning summaries | ✅ GA | 2025-06-03 | Available for o‑series models only. |
 | Encrypted reasoning tokens | ✅ GA | 2025-06-03 | Persists reasoning context across turns. |
 | Optimized token caching | ✅ GA | 2025-06-03 | Saves ~50–75 % tokens on tuned models. |


### PR DESCRIPTION
## Summary
- remove `ENABLE_NATIVE_TOOL_CALLING` valve and always use native tools when supported
- update helper to set `function_calling` to `native` when necessary
- document changes and bump version to 0.8.0

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_683fd17aac98832ea6c2d59f74f9897d