### PR TITLE
Refactor streaming loop

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2025-06-05
+- Fixed reasoning summaries leaking into subsequent turns.
+- Added missing output items to subsequent requests.
+- Guarded reasoning event emission when no emitter is provided.
+
 ## [0.8.1] - 2025-06-05
 - Refactored `_multi_turn_streaming` for simplicity and removed unused output buffer.
 - Fixed log citation retrieval when debugging.


### PR DESCRIPTION
## Summary
- refactor `_multi_turn_streaming` for clarity
- fix reasoning summary handling across loops
- include previous output items in follow-up requests
- guard reasoning summary events when emitter is absent
- bump version to 0.8.2

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6841380299fc832ebfcec88d23f293d4