### PR TITLE
Implement _multi_turn_non_streaming

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2025-06-06
+- Implemented `_multi_turn_non_streaming` with single-request flow.
+
 ## [0.8.2] - 2025-06-05
 - Fixed reasoning summaries leaking into subsequent turns.
 - Added missing output items to subsequent requests.


### PR DESCRIPTION
## Summary
- implement `_multi_turn_non_streaming` to perform a single non-streaming
  request to OpenAI's Responses API
- add helper `_call_llm_non_stream`
- bump `openai_responses_manifold` to version 0.8.3
- document change in CHANGELOG
- clean up unused imports and variables

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68426fc96238832ead6d1c68be0e37db