### PR TITLE
Implement task handler for Responses manifold

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-06-07
+- Added basic task model support via `_handle_task`.
+
 ## [0.8.4] - 2025-06-06
 - Enabled tool-call loops in `_multi_turn_non_streaming` for parity with the streaming path.
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -15,7 +15,7 @@
 | Encrypted reasoning tokens | ✅ GA | 2025-06-03 | Persists reasoning context across turns. |
 | Optimized token caching | ✅ GA | 2025-06-03 | Saves ~50–75 % tokens on tuned models. |
 | Web search tool | ✅ GA | 2025-06-03 | Automatically invoked or toggled manually. |
-| Task model support | 🔄 In-progress | 2025-06-03 | Roadmap item. |
+| Task model support | ✅ GA | 2025-06-07 | Basic support implemented. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (i.e., upload image and ask it to change it) |
 | File upload / file search tool integration | 🕒 Backlog | 2025-06-03 | Roadmap item. |

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 0.8.4
+version: 0.9.0
 license: MIT
 requirements: orjson
 """
@@ -268,6 +268,35 @@ class Pipe:
 
         except Exception as caught_exception:
             await self._emit_error(__event_emitter__, caught_exception, show_error_message=True, show_error_log_citation=True, done=True)
+
+    # -------------------------------------------------------------------------
+    # Helper: Handle simple task models
+    # -------------------------------------------------------------------------
+    async def _handle_task(
+        self,
+        body: Dict[str, Any],
+        __user__: Dict[str, Any],
+        __request__: Request,
+        __event_emitter__: Callable[[Dict[str, Any]], Awaitable[None]],
+        __metadata__: Dict[str, Any],
+        __tools__: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Call the Responses API for task type requests."""
+
+        valves = self._merge_valves(self.valves, self.UserValves.model_validate(__user__.get("valves", {})))
+        model_id = str(body.get("model", "")).split(".", 1)[-1].strip()
+        transformed_body = {
+            "model": model_id,
+            "instructions": "",
+            "input": body.get("messages"),
+            "stream": False,
+        }
+
+        return await self._call_llm_non_stream(
+            transformed_body,
+            api_key=valves.API_KEY,
+            base_url=valves.BASE_URL,
+        )
                 
     # -------------------------------------------------------------------------
     # 1) Multi-turn loop: STREAMING


### PR DESCRIPTION
## Summary
- implement `_handle_task` for the Responses manifold
- bump version to `0.9.0`
- document basic task support and update CHANGELOG

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6842770dc6e8832eab8a5d970f012ab4