### PR TITLE
Implement task handler for Responses manifold

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2025-06-08
+- Returned OpenAI-compatible dict from `_handle_task`.
+
+## [0.9.0] - 2025-06-07
+- Added basic task model support via `_handle_task`.
+
 ## [0.8.4] - 2025-06-06
 - Enabled tool-call loops in `_multi_turn_non_streaming` for parity with the streaming path.
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -15,7 +15,7 @@
 | Encrypted reasoning tokens | ✅ GA | 2025-06-03 | Persists reasoning context across turns. |
 | Optimized token caching | ✅ GA | 2025-06-03 | Saves ~50–75 % tokens on tuned models. |
 | Web search tool | ✅ GA | 2025-06-03 | Automatically invoked or toggled manually. |
-| Task model support | 🔄 In-progress | 2025-06-03 | Roadmap item. |
+| Task model support | ✅ GA | 2025-06-08 | Basic support implemented. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (i.e., upload image and ask it to change it) |
 | File upload / file search tool integration | 🕒 Backlog | 2025-06-03 | Roadmap item. |


### PR DESCRIPTION
## Summary
- implement `_handle_task` for the Responses manifold
- bump version to `0.9.1`
- document basic task support and update CHANGELOG

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6842770dc6e8832eab8a5d970f012ab4