### PR TITLE
Fix context-aware log level

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2025-06-09
+- Reworked logger setup with a custom `Logger` subclass so session-specific log
+  levels work correctly.
+
+## [0.9.2] - 2025-06-09
+- Fixed per-session log level filtering using `ContextVar`-based filters.
+
 ## [0.9.1] - 2025-06-08
 - Returned OpenAI-compatible dict from `_handle_task`.
 

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 0.9.1
+version: 0.9.3
 license: MIT
 requirements: orjson
 """
@@ -69,6 +69,21 @@ FEATURE_SUPPORT = {
 current_session_id = ContextVar("current_session_id", default=None)
 current_log_level = ContextVar("current_log_level", default=logging.INFO)
 logs_by_msg_id = defaultdict(list)
+
+
+class SessionIDFilter(logging.Filter):
+    """Attach the current session ID to each log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        record.session_id = getattr(record, "session_id", None) or current_session_id.get()
+        return True
+
+
+class ContextLevelFilter(logging.Filter):
+    """Filter records using the per-session log level from :data:`current_log_level`."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401
+        return record.levelno >= current_log_level.get()
 
 # Precompiled regex for stripping <details> blocks from assistant text
 DETAILS_RE = re.compile(r"<details\b[^>]*>.*?<\/details>", flags=re.IGNORECASE | re.DOTALL)
@@ -139,12 +154,23 @@ class Pipe:
         
         self.session: aiohttp.ClientSession | None = None
         
+        class ContextLogger(logging.Logger):
+            """Logger with :func:`isEnabledFor` backed by :data:`current_log_level`."""
+
+            def isEnabledFor(self, level: int) -> bool:  # noqa: D401
+                if self.manager.disable >= level:
+                    return False
+                return level >= current_log_level.get()
+
+        old_cls = logging.getLoggerClass()
+        logging.setLoggerClass(ContextLogger)
         self.log = logging.getLogger(__name__)
+        logging.setLoggerClass(old_cls)
         if not self.log.handlers:  # Prevent duplicate logs
             self.log.propagate = False
             self.log.setLevel(logging.DEBUG)
-            self.log.addFilter(lambda r: (setattr(r, "session_id", getattr(r, "session_id", None) or current_session_id.get()) or True))
-            self.log.addFilter(lambda r: r.levelno >= current_log_level.get())
+            self.log.addFilter(SessionIDFilter())
+            self.log.addFilter(ContextLevelFilter())
 
             console = logging.StreamHandler(sys.stdout)
             console.setFormatter(logging.Formatter("%(levelname)s [mid=%(session_id)s] %(message)s"))


### PR DESCRIPTION
## Summary
- ensure log filtering per session by using a custom Logger subclass
- update version to 0.9.3 and document the change

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68428483a2e8832e90e291f9e35c0f93