### PR TITLE
Fix streaming response edge case

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2025-06-10
+- Respect `PERSIST_TOOL_RESULTS` valve when saving tool outputs.
+- Avoid errors if a streaming response ends without `response.completed`.
+
 ## [0.9.3] - 2025-06-09
 - Reworked logger setup with a custom `Logger` subclass so session-specific log
   levels work correctly.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 0.9.3
+version: 0.9.4
 license: MIT
 requirements: orjson
 """
@@ -552,6 +552,10 @@ class Pipe:
                         yield ""
                         break # Exit the streaming loop to process the final response
                 
+                if final_response_data is None:
+                    self.log.error("Streaming ended without a final response.")
+                    break
+
                 # Capture the final output items
                 collected_items.extend(final_response_data.get("output", []))
                 usage = final_response_data.get("usage", {})
@@ -594,7 +598,7 @@ class Pipe:
                 await self._emit_completion(event_emitter, usage=total_usage, done=True)
 
             # If PERSIST_TOOL_RESULTS is enabled, append all collected items (function_call, function_call_output, web_search, image_generation, etc.) to the chat message history
-            if collected_items:
+            if valves.PERSIST_TOOL_RESULTS and collected_items:
                 db_items = [item for item in collected_items if item.get("type") != "message"]
                 if db_items:
                     add_openai_response_items_to_chat_by_id_and_message_id(


### PR DESCRIPTION
## Summary
- handle streaming sessions that end without a `response.completed` event
- honor `PERSIST_TOOL_RESULTS` valve when saving tool outputs
- bump OpenAI Responses Manifold to 0.9.4

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68428f44b624832ebc15034a0c8ce89f