### PR TITLE
Update responses manifold docs

### DIFF
--- a/.tests/conftest.py
+++ b/.tests/conftest.py
@@ -56,7 +56,14 @@ misc_mod = types.ModuleType("open_webui.utils.misc")
 def get_message_list(*args, **kwargs):
     return []
 
+def get_system_message(messages):
+    for msg in messages or []:
+        if msg.get("role") == "system":
+            return msg
+    return None
+
 misc_mod.get_message_list = get_message_list
+misc_mod.get_system_message = get_system_message
 utils_mod.misc = misc_mod
 
 tasks_mod = types.ModuleType("open_webui.tasks")

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2025-06-06
+- Refactored Responses API integration and introduced typed request models.
+- Improved message and tool transformation.
+- Added full support for task models via `_handle_task`.
+
 ## [0.8.2] - 2025-06-05
 - Fixed reasoning summaries leaking into subsequent turns.
 - Added missing output items to subsequent requests.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -15,7 +15,7 @@
 | Encrypted reasoning tokens | ✅ GA | 2025-06-03 | Persists reasoning context across turns. |
 | Optimized token caching | ✅ GA | 2025-06-03 | Saves ~50–75 % tokens on tuned models. |
 | Web search tool | ✅ GA | 2025-06-03 | Automatically invoked or toggled manually. |
-| Task model support | ✅ GA | 2025-06-08 | Basic support implemented. |
+| Task model support | ✅ GA | 2025-06-06 | Task models fully supported via the Responses API. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (i.e., upload image and ask it to change it) |
 | File upload / file search tool integration | 🕒 Backlog | 2025-06-03 | Roadmap item. |

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -5,7 +5,7 @@ author: Justin Kropp
 author_url: https://github.com/jrkropp
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
-version: 0.8.2
+version: 0.8.3
 license: MIT
 requirements: orjson
 """


### PR DESCRIPTION
## Summary
- update changelog for OpenAI Responses Manifold to 0.8.3
- update README features row to note task model support
- bump pipe version number
- extend test stubs for `get_system_message`

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md functions/pipes/openai_responses_manifold/README.md .tests/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_684352929a94832e910bf0b302a1bb01