### PR TITLE
Fix reasoning summary dictionary init

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Refactored Responses API integration and introduced typed request models.
 - Improved message and tool transformation.
 - Added full support for task models via `_handle_task`.
+- Fixed initialization of the reasoning dictionary when enabling summaries.
 
 ## [0.8.2] - 2025-06-05
 - Fixed reasoning summaries leaking into subsequent turns.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -316,7 +316,7 @@ class Pipe:
 
             # Conditionally set reasoning summary
             if completions_body.model in FEATURE_SUPPORT["reasoning_summary"] and valves.ENABLE_REASONING_SUMMARY:
-                responses_body.reasoning = responses_body.reasoning or []
+                responses_body.reasoning = responses_body.reasoning or {}
                 responses_body.reasoning["summary"] = valves.ENABLE_REASONING_SUMMARY
 
             # Conditionally include reasoning.encrypted_content


### PR DESCRIPTION
## Summary
- fix initialization of `responses_body.reasoning`
- document the fix in CHANGELOG

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684354ae013c832e801c2e8d574f1bc9