### PR TITLE
Simplify status strings

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.8.4] - 2025-06-07
 - Fixed missing done flag in `_emit_error` causing hanging requests.
 - Emitted log citations using new `SessionLogger` store.
+- Simplified progress status messages.
 
 ## [0.8.3] - 2025-06-06
 - Refactored Responses API integration and introduced typed request models.


### PR DESCRIPTION
## Summary
- shorten tool start/finish messages for the OpenAI Responses pipeline
- document status message simplification

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68439fe7c994832e9348cc88af5f807b