### PR TITLE
Add Input Inspector pipe

### DIFF
--- a/.tests/test_input_inspector.py
+++ b/.tests/test_input_inspector.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+
+def test_importable():
+    mod = import_module('functions.pipes.input_inspector.input_inspector')
+    assert hasattr(mod, 'Pipe')

--- a/functions/pipes/input_inspector/README.md
+++ b/functions/pipes/input_inspector/README.md
@@ -1,0 +1,10 @@
+# Input Inspector
+A simple demonstration pipe that shows the contents of each pipe input argument.
+It emits a citation block for `body`, `__metadata__`, `__user__`, `__request__`,
+`__files__` and `__tools__` so you can inspect the data WebUI passes to a
+pipeline.
+
+## Usage
+1. Copy `input_inspector.py` to your WebUI under **Admin ▸ Pipelines**.
+2. Enable the pipe and run a chat. The pipe will emit citation blocks containing
+the JSON for each argument.

--- a/functions/pipes/input_inspector/input_inspector.py
+++ b/functions/pipes/input_inspector/input_inspector.py
@@ -1,0 +1,86 @@
+"""
+title: Input Inspector
+id: input_inspector
+author: OpenAI Codex
+funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
+description: Emit citations showing the data passed to a pipe for debugging.
+version: 0.1.0
+license: MIT
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Any, AsyncGenerator, Awaitable, Callable
+
+from fastapi import Request
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: dict[str, Any],
+        __user__: dict[str, Any],
+        __request__: Request,
+        __event_emitter__: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        __files__: list[dict[str, Any]] | None = None,
+        __metadata__: dict[str, Any] | None = None,
+        __tools__: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[str, None] | str:
+        """Send citation blocks for each argument and return a short message."""
+
+        async def emit(name: str, value: Any) -> None:
+            if __event_emitter__ is None:
+                return
+
+            serial = _safe_json(value)
+            await __event_emitter__(
+                {
+                    "type": "citation",
+                    "data": {
+                        "document": [json.dumps(serial, indent=2)],
+                        "metadata": [
+                            {
+                                "date_accessed": datetime.datetime.utcnow().isoformat(),
+                                "source": name,
+                            }
+                        ],
+                        "source": {"name": name},
+                    },
+                }
+            )
+
+        await emit("body", body)
+        await emit("__metadata__", __metadata__ or {})
+        await emit("__user__", __user__)
+        await emit("__request__", {
+            "method": __request__.method,
+            "url": str(__request__.url),
+            "headers": dict(__request__.headers),
+        })
+        await emit("__files__", __files__ or [])
+        await emit("__tools__", __tools__ or {})
+
+        return "Input inspection complete. See citations for details."
+
+def _safe_json(obj: Any) -> Any:
+    """Recursively convert obj to JSON-serializable form."""
+
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    if isinstance(obj, dict):
+        return {k: _safe_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_safe_json(v) for v in obj]
+    if hasattr(obj, "dict"):
+        try:
+            return _safe_json(obj.dict())
+        except Exception:  # pragma: no cover - best effort
+            pass
+    if hasattr(obj, "model_dump"):
+        try:
+            return _safe_json(obj.model_dump())
+        except Exception:  # pragma: no cover - best effort
+            pass
+    return str(obj)


### PR DESCRIPTION
## Summary
- add Input Inspector pipe to emit citations for each input argument
- document how to use the new pipe
- test importability

## Testing
- `pre-commit run --files functions/pipes/input_inspector/input_inspector.py functions/pipes/input_inspector/README.md .tests/test_input_inspector.py`

------
https://chatgpt.com/codex/tasks/task_e_684459406d6c832e82f950ac72dd3996