### PR TITLE
Improve input inspector privacy

### DIFF
--- a/functions/pipes/input_inspector/README.md
+++ b/functions/pipes/input_inspector/README.md
@@ -4,6 +4,9 @@ It emits a citation block for `body`, `__metadata__`, `__user__`, `__request__`,
 `__files__` and `__tools__` so you can inspect the data WebUI passes to a
 pipeline.
 
+Sensitive headers like `Authorization` and `Cookie` are redacted from
+`__request__` to avoid leaking private information.
+
 ## Usage
 1. Copy `input_inspector.py` to your WebUI under **Admin ▸ Pipelines**.
 2. Enable the pipe and run a chat. The pipe will emit citation blocks containing


### PR DESCRIPTION
## Summary
- redact sensitive headers in the input inspector
- document header redaction in the Input Inspector README

## Testing
- `pre-commit run --files functions/pipes/input_inspector/input_inspector.py functions/pipes/input_inspector/README.md .tests/test_input_inspector.py`

------
https://chatgpt.com/codex/tasks/task_e_68445d38b790832eac77fbb27311b5d9