### PR TITLE
Add redaction valve to input inspector

### DIFF
--- a/functions/pipes/input_inspector/README.md
+++ b/functions/pipes/input_inspector/README.md
@@ -5,7 +5,8 @@ It emits a citation block for `body`, `__metadata__`, `__user__`, `__request__`,
 pipeline.
 
 Sensitive headers like `Authorization` and `Cookie` are redacted from
-`__request__` to avoid leaking private information.
+`__request__` to avoid leaking private information. The `REDACT_REQUEST`
+valve controls this behavior and defaults to `True`.
 
 ## Usage
 1. Copy `input_inspector.py` to your WebUI under **Admin ▸ Pipelines**.


### PR DESCRIPTION
## Summary
- add new `REDACT_REQUEST` valve to the `Input Inspector` pipe
- update sanitization logic to respect the valve
- document the new valve in the pipe README

## Testing
- `pre-commit run --files functions/pipes/input_inspector/input_inspector.py functions/pipes/input_inspector/README.md .tests/test_input_inspector.py`

------
https://chatgpt.com/codex/tasks/task_e_68445e86b4f8832e889e01f6dc273818