### PR TITLE
Improve Input Inspector serialization clarity

### DIFF
--- a/functions/pipes/input_inspector/README.md
+++ b/functions/pipes/input_inspector/README.md
@@ -8,6 +8,10 @@ Sensitive headers like `Authorization` and `Cookie` are redacted from
 `__request__` to avoid leaking private information. The `REDACT_REQUEST`
 valve controls this behavior and defaults to `True`.
 
+Values that can't be serialized to JSON are replaced with a placeholder
+like `<UNSERIALIZABLE ClassName>` so the overall structure of the input
+remains visible.
+
 ## Usage
 1. Copy `input_inspector.py` to your WebUI under **Admin ▸ Pipelines**.
 2. Enable the pipe and run a chat. The pipe will emit citation blocks containing

--- a/functions/pipes/input_inspector/input_inspector.py
+++ b/functions/pipes/input_inspector/input_inspector.py
@@ -4,7 +4,7 @@ id: input_inspector
 author: OpenAI Codex
 funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 description: Emit citations showing the data passed to a pipe for debugging.
-version: 0.1.0
+version: 0.1.1
 license: MIT
 """
 
@@ -112,4 +112,4 @@ def _safe_json(obj: Any) -> Any:
             return _safe_json(obj.model_dump())
         except Exception:  # pragma: no cover - best effort
             pass
-    return str(obj)
+    return f"<UNSERIALIZABLE {type(obj).__name__}>"


### PR DESCRIPTION
## Summary
- bump Input Inspector to 0.1.1
- replace unserializable values with `<UNSERIALIZABLE ClassName>` placeholder
- document placeholder behaviour in Input Inspector README

## Testing
- `pre-commit run --files functions/pipes/input_inspector/input_inspector.py functions/pipes/input_inspector/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684461db304c832ebb90928c2963852f