### PR TITLE
Update pipe input docs for tool behavior

### DIFF
--- a/docs/pipe_input.md
+++ b/docs/pipe_input.md
@@ -29,7 +29,10 @@ Holds the conversation request. Typical keys include:
 * `model` – the model identifier, e.g. `"openai_responses.gpt-4.1"`.
 * `messages` – list of `{role, content}` chat messages.
 * `stream_options` – options such as `include_usage: true`.
-* `tools` – list of tool/function definitions.
+* `tools` – list of tool/function definitions. This field is **only** present
+  when native function calling is enabled for the selected model. When filled in,
+  each entry matches the OpenAI Completions API schema so it can be sent
+  directly to OpenAI.
 
 Example:
 
@@ -56,8 +59,12 @@ Example:
       }
     }
   ]
-}
+ }
 ```
+
+When native function calling is **disabled**, the `tools` key will be absent and
+Open WebUI runs tools internally. In that case use the `__tools__` argument
+described later.
 
 ## 2. `__user__`
 
@@ -246,7 +253,14 @@ Example:
 
 ## 7. `__tools__`
 
-Dictionary of tool definitions keyed by tool name. Each entry typically includes a `tool_id`, `callable`, `spec` describing parameters, and optional metadata.
+Dictionary of tool definitions keyed by tool name. This argument is populated
+whenever one or more tools are selected and is available regardless of whether
+native function calling is enabled. It is generally safer to rely on this
+mapping than on `body['tools']` because the structure stays consistent and each
+entry exposes a callable for direct invocation.
+
+Each entry includes a `tool_id`, a `callable`, a `spec` describing parameters,
+and optional metadata.
 
 Example:
 


### PR DESCRIPTION
## Summary
- document that `body['tools']` only appears when native function calling is enabled
- add note about using `__tools__` when function calling is disabled
- clarify purpose of the `__tools__` argument

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6844744f5e50832ea0d7d05028eda8d1