### PR TITLE
Organize filters into subfolders

### DIFF
--- a/functions/filters/AGENTS.md
+++ b/functions/filters/AGENTS.md
@@ -1,0 +1,23 @@
+# Filter Instructions
+
+This guide applies to all files in the `functions/filters` directory.
+
+## Structure
+- Each filter lives in its own folder matching the Python file name.
+- A filter folder contains `README.md`, `CHANGELOG.md` and `<filter>.py`.
+
+## Versioning
+
+Each filter's docstring must include a `version:` field. We follow **Semantic Versioning** (`MAJOR.MINOR.PATCH`).
+
+## Changelog Updates
+When a filter is modified, update its `version` only once per day and record the changes under the same version in `CHANGELOG.md` using the format:
+
+```
+## [x.y.z] - YYYY-MM-DD
+```
+
+Documentation-only edits do not require a version bump.
+
+## Code Style
+Run `pre-commit` before committing changes to ensure the repository tests and style checks pass.

--- a/functions/filters/README.md
+++ b/functions/filters/README.md
@@ -1,8 +1,19 @@
-# Filters Guide
+# Filters
 
-Filters are lightweight plugins that run before, during and after a pipe. Each file can define `inlet`, `stream` and `outlet` handlers to modify chat data or emit events.
+Each filter lives inside its own folder. The folder name matches the filter title and includes:
 
-## Basic Structure
+- `README.md` – short description and usage notes
+- `CHANGELOG.md` – recorded history following Keep a Changelog
+- `<filter>.py` – the filter implementation
+
+Upload the Python file via the Functions API to install. Example filters include:
+
+- `web_search_toggle_filter`
+- `create_image_toggle_filter`
+- `reason_toggle_filter`
+- `debug_toggle_filter`
+
+The rest of this document explains the general filter structure.
 
 ```python
 from pydantic import BaseModel
@@ -21,11 +32,7 @@ class Filter:
         return body
 ```
 
-Only the methods you implement are called. `priority` controls execution order when multiple filters are active.
-
-## Loading
-
-Upload the file via the Functions API. Optional packages can be listed in a frontmatter block and will be installed automatically:
+Only the methods you implement are called. `priority` controls execution order when multiple filters are active. Upload optional dependencies via a frontmatter block:
 
 ```python
 """
@@ -33,19 +40,4 @@ requirements: httpx
 """
 ```
 
-The loader caches each module under `request.app.state.FUNCTIONS`.
-
-## Valves and User Settings
-
-Filters may expose extra options via `Valves` and `UserValves` classes. These are hydrated from the database on each call so settings can be tweaked without re-uploading the code.
-
-Set `file_handler = True` if the filter consumes uploaded files itself. Only parameters declared in a handler's signature are provided (e.g. `body`, `event`, `__user__`).
-
-See `external/FILTER_GUIDE.md` for deeper middleware notes and additional examples.
-
-## Example filters
-
-- `web_search_toggle_filter.py` – enable web search with a toggle.
-- `create_image_filter.py` – inject the `image_generation` tool with configurable `SIZE` and `QUALITY` valves.
-- `reason_filter.py` – temporarily route a request to another model.
-- `debug_toggle_filter.py` – capture logs and inputs for the current session.
+Filters may expose user-tweakable options via `Valves` and `UserValves` classes. Set `file_handler = True` if the filter consumes uploaded files itself. See `external/FILTER_GUIDE.md` for advanced notes.

--- a/functions/filters/create_image_toggle_filter/CHANGELOG.md
+++ b/functions/filters/create_image_toggle_filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the Create Image Toggle Filter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-07
+- Initial release.

--- a/functions/filters/create_image_toggle_filter/README.md
+++ b/functions/filters/create_image_toggle_filter/README.md
@@ -1,0 +1,4 @@
+# Create Image Toggle Filter
+Injects the image_generation tool with configurable size and quality valves.
+
+Copy `create_image_toggle_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/create_image_toggle_filter/create_image_toggle_filter.py
+++ b/functions/filters/create_image_toggle_filter/create_image_toggle_filter.py
@@ -4,6 +4,7 @@ id: create_image_toggle_filter
 description: Injects the image_generation tool with configurable size and quality.
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
 required_open_webui_version: 0.6.10
+version: 0.1.0
 """
 
 from __future__ import annotations

--- a/functions/filters/debug_toggle_filter/CHANGELOG.md
+++ b/functions/filters/debug_toggle_filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the Debug Toggle Filter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-07
+- Initial release.

--- a/functions/filters/debug_toggle_filter/README.md
+++ b/functions/filters/debug_toggle_filter/README.md
@@ -1,0 +1,4 @@
+# Debug Toggle Filter
+Provides a toggle to attach session logs and input data as citations for debugging.
+
+Copy `debug_toggle_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/debug_toggle_filter/debug_toggle_filter.py
+++ b/functions/filters/debug_toggle_filter/debug_toggle_filter.py
@@ -4,6 +4,7 @@ id: debug_toggle_filter
 description: Attach session logs and input data as citations for debugging.
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
 required_open_webui_version: 0.6.10
+version: 0.1.0
 """
 
 from __future__ import annotations

--- a/functions/filters/reason_toggle_filter/CHANGELOG.md
+++ b/functions/filters/reason_toggle_filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the Reason Toggle Filter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-07
+- Initial release.

--- a/functions/filters/reason_toggle_filter/README.md
+++ b/functions/filters/reason_toggle_filter/README.md
@@ -1,0 +1,4 @@
+# Reason Toggle Filter
+Temporarily routes a request to another model.
+
+Copy `reason_toggle_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/reason_toggle_filter/reason_toggle_filter.py
+++ b/functions/filters/reason_toggle_filter/reason_toggle_filter.py
@@ -4,6 +4,7 @@ id: reason_filter
 description: Think before responding.
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
 required_open_webui_version: 0.6.10
+version: 0.1.0
 """
 
 from __future__ import annotations

--- a/functions/filters/web_search_toggle_filter/CHANGELOG.md
+++ b/functions/filters/web_search_toggle_filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the Web Search Toggle Filter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-07
+- Initial release.

--- a/functions/filters/web_search_toggle_filter/README.md
+++ b/functions/filters/web_search_toggle_filter/README.md
@@ -1,0 +1,4 @@
+# Web Search Toggle Filter
+Adds a web search toggle using OpenAI's built-in tool.
+
+Copy `web_search_toggle_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/web_search_toggle_filter/web_search_toggle_filter.py
+++ b/functions/filters/web_search_toggle_filter/web_search_toggle_filter.py
@@ -4,6 +4,7 @@ id: web_search_toggle_filter
 description: Search the web
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
 required_open_webui_version: 0.6.10
+version: 0.1.0
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- restructure `functions/filters` so each filter lives in its own folder
- add README and CHANGELOG files for every filter
- document filter workflow in a new `functions/filters/AGENTS.md`
- update root README for filters
- embed a `version:` field in each filter's docstring

## Testing
- `pre-commit run --files functions/filters/README.md functions/filters/AGENTS.md functions/filters/create_image_toggle_filter/create_image_toggle_filter.py functions/filters/debug_toggle_filter/debug_toggle_filter.py functions/filters/reason_toggle_filter/reason_toggle_filter.py functions/filters/web_search_toggle_filter/web_search_toggle_filter.py functions/filters/*/README.md functions/filters/*/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684489d2b74c832eb8242d17a55122fe