### PR TITLE
Fix debug filter log capture

### DIFF
--- a/functions/filters/debug_toggle_filter/CHANGELOG.md
+++ b/functions/filters/debug_toggle_filter/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.1.0] - 2025-06-07
 - Initial release.
+
+## [0.1.1] - 2025-06-07
+- Use shared `SessionLogger` from OpenAI Responses pipe when available.
+- Added inlet and outlet log statements to ensure output.


### PR DESCRIPTION
## Summary
- reuse SessionLogger from the OpenAI responses pipe
- always log inlet and outlet activity

## Testing
- `pre-commit run --files functions/filters/debug_toggle_filter/debug_toggle_filter.py functions/filters/debug_toggle_filter/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68448de1623c832ea5e4d4bf80b61c3c