### PR TITLE
docs: add MCP tool backlog item

### DIFF
--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -23,6 +23,7 @@
 | Computer use tool | 🕒 Backlog | 2025-06-03 | TBD.  Read more [here](https://platform.openai.com/docs/guides/tools-computer-use) |
 | Live conversational voice via talk feature | 🕒 Backlog | 2025-06-03 | TBD.  Requires patching backend code (possible via pipe however need to think through best approach) |
 | Dynamic chat titles | 🕒 Backlog | 2025-06-03 | TBD.  Leverage title to show progress of long running tasks. |
+| MCP tool support | 🕒 Backlog | 2025-06-07 | Enable remote MCP servers via the Responses API. [Learn more](https://platform.openai.com/docs/guides/tools-remote-mcp) |
 
 ### Quality of life improvements
 - **Pseudo-models**


### PR DESCRIPTION
## Summary
- document remote MCP tool support in backlog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6847036a662c832ea74637b106d56e9d