### PR TITLE
Add OpenAI Responses companion filter scaffolding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ This folder stores internal notes and planning documents for extensions. Files h
 - `file_storage.md` – where uploaded files and generated images are kept and how to attach them to chats.
 - `responses_manifold.md` – front-end overview of the OpenAI Responses manifold and why it persists data.
 - `file_handler.md` – how filters and tools disable the built-in file processor.
+- `responses_file_upload.md` – plan for the companion filter that handles file uploads.

--- a/docs/responses_file_upload.md
+++ b/docs/responses_file_upload.md
@@ -1,0 +1,10 @@
+# OpenAI Responses File Upload
+
+This note outlines the plan for a companion filter that will manage file uploads when using the OpenAI Responses manifold.
+
+## Goals
+- Disable WebUI's built-in file handler.
+- Upload files directly to OpenAI's API before the request reaches the manifold.
+- Persist file references in the chat record for later retrieval.
+
+The implementation will convert image uploads to file objects when required. The exact API endpoints and storage format are still under evaluation.

--- a/functions/filters/openai_responses_companion_filter/CHANGELOG.md
+++ b/functions/filters/openai_responses_companion_filter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to the OpenAI Responses Companion Filter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-10
+- Initial release.

--- a/functions/filters/openai_responses_companion_filter/README.md
+++ b/functions/filters/openai_responses_companion_filter/README.md
@@ -1,0 +1,5 @@
+# OpenAI Responses Companion Filter
+
+Disables the built-in file handler and prepares files for upload when using the OpenAI Responses manifold.
+
+Copy `openai_responses_companion_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/openai_responses_companion_filter/openai_responses_companion_filter.py
+++ b/functions/filters/openai_responses_companion_filter/openai_responses_companion_filter.py
@@ -1,0 +1,49 @@
+"""
+title: OpenAI Responses Companion
+id: openai_responses_companion_filter
+description: Handles file uploads for the OpenAI Responses manifold.
+git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
+required_open_webui_version: 0.6.10
+version: 0.1.0
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Filter:
+    """Companion filter for OpenAI Responses manifold.
+
+    This filter disables the built-in file handler and will later upload files
+    using the OpenAI Responses API. Currently it only returns the request body
+    unchanged.
+    """
+
+    class Valves(BaseModel):
+        """Configurable settings for file upload handling."""
+
+        ALLOW_IMAGES: bool = True
+        ALLOW_FILES: bool = True
+
+    def __init__(self) -> None:
+        # Signal to Open WebUI that we will manage uploaded files ourselves
+        self.file_handler = True
+        self.valves = self.Valves()
+
+    async def inlet(
+        self,
+        body: dict,
+        __event_emitter__: Optional[callable] = None,
+        __metadata__: Optional[dict] = None,
+    ) -> dict:
+        """Process files before they reach the manifold.
+
+        The actual upload logic will be implemented in a future release.
+        """
+        return body
+
+    async def outlet(self, body: dict) -> dict:
+        """Placeholder for response post-processing."""
+        return body


### PR DESCRIPTION
## Summary
- add docs for planning file uploads
- scaffold the OpenAI Responses Companion filter

## Testing
- `pre-commit run --files functions/filters/openai_responses_companion_filter/openai_responses_companion_filter.py docs/README.md docs/responses_file_upload.md functions/filters/openai_responses_companion_filter/README.md functions/filters/openai_responses_companion_filter/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68478c680bcc832e839dbce92a7101bf