### PR TITLE
Add reasoning effort valve

### DIFF
--- a/functions/filters/reason_toggle_filter/CHANGELOG.md
+++ b/functions/filters/reason_toggle_filter/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to the Reason Toggle Filter are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-06-08
+- Added `REASONING_EFFORT` valve to control `reasoning_effort` parameter.
+
 ## [0.1.0] - 2025-06-07
 - Initial release.

--- a/functions/filters/reason_toggle_filter/README.md
+++ b/functions/filters/reason_toggle_filter/README.md
@@ -1,4 +1,10 @@
 # Reason Toggle Filter
 Temporarily routes a request to another model.
 
+## Valves
+
+- `REASONING_EFFORT`: "low", "medium", "high", or "not set" (default). When set
+  to a value other than "not set", the filter adds a `reasoning_effort` field to
+  the request body.
+
 Copy `reason_toggle_filter.py` to Open WebUI under **Admin ▸ Filters** to enable.

--- a/functions/filters/reason_toggle_filter/reason_toggle_filter.py
+++ b/functions/filters/reason_toggle_filter/reason_toggle_filter.py
@@ -4,16 +4,18 @@ id: reason_filter
 description: Think before responding.
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
 required_open_webui_version: 0.6.10
-version: 0.1.0
+version: 0.2.0
 """
 
 from __future__ import annotations
+from typing import Literal
 from pydantic import BaseModel
 
 
 class Filter:
     class Valves(BaseModel):
         MODEL: str = "o4-mini"
+        REASONING_EFFORT: Literal["low", "medium", "high", "not set"] = "not set"
 
     def __init__(self) -> None:
         self.valves = self.Valves()
@@ -21,6 +23,9 @@ class Filter:
 
     async def inlet(self, body: dict) -> dict:
         body["model"] = self.valves.MODEL
+        effort = self.valves.REASONING_EFFORT
+        if effort != "not set":
+            body["reasoning_effort"] = effort
         return body
 
     async def outlet(self, body: dict) -> dict:


### PR DESCRIPTION
## Summary
- add `REASONING_EFFORT` valve to Reason Toggle filter to set `reasoning_effort`
- document new valve in README and bump filter version
- note changes in changelog

## Testing
- `pre-commit run --files functions/filters/reason_toggle_filter/reason_toggle_filter.py functions/filters/reason_toggle_filter/README.md functions/filters/reason_toggle_filter/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68484d0b9244832eadaab7370d2b60f5