### PR TITLE
Fix metadata update in reason_toggle_filter

### DIFF
--- a/functions/filters/reason_toggle_filter/CHANGELOG.md
+++ b/functions/filters/reason_toggle_filter/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.3.1] - 2025-06-10
 - Update metadata with rerouted model information.
 - Remove unused event emitter logic for model switching.
+- Fix model metadata not updating when valve changes.
 
 ## [0.1.0] - 2025-06-07
 - Initial release.

--- a/functions/filters/reason_toggle_filter/reason_toggle_filter.py
+++ b/functions/filters/reason_toggle_filter/reason_toggle_filter.py
@@ -20,45 +20,45 @@ class Filter:
     def __init__(self) -> None:
         self.valves = self.Valves()
         self.toggle = True
-        self.icon = "data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgY2xhc3M9ImgtWzE4cHldIHctWzE4cHldIj48cGF0aCBkPSJtMTIgM2MtMy41ODUgMC02LjUgMi45MjI1LTYuNSA2LjUzODUgMCAyLjI4MjYgMS4xNjIgNC4yOTEzIDIuOTI0OCA1LjQ2MTVoNy4xNTA0YzEuNzYyOC0xLjE3MDIgMi45MjQ4LTMuMTc4OSAyLjkyNDgtNS40NjE1IDAtMy42MTU5LTIuOTE1LTYuNTM4NS02LjUtNi41Mzg1em0yLjg2NTMgMTRoLTUuNzMwNnYxaDUuNzMwNnYtMXptLTEuMTMyOSAzSC03LjQ2NDhjMC4zNDU4IDAuNTk3OCAwLjk5MjEgMSAxLjczMjQgMXMxLjM4NjYtMC40MDIyIDEuNzMyNC0xem0tNS42MDY0IDBjMC40NDQwMyAxLjcyNTIgMi4wMTAxIDMgMy44NzQgM3MzLjQzLTEuMjc0OCAzLjg3NC0zYzAuNTQ4My0wLjAwNDcgMC45OTEzLTAuNDUwNiAwLjk5MTMtMXYtMi40NTkzYzIuMTk2OS0xLjU0MzEgMy42MzQ3LTQuMTA0NSAzLjYzNDctNy4wMDIyIDAtNC43MTA4LTMuODAwOC04LjUzODUtOC41LTguNTM4NS00LjY5OTIgMC04LjUgMy44Mjc2LTguNSA4LjUzODUgMCAyLjg5NzcgMS40Mzc4IDUuNDU5MSAzLjYzNDcgNy4wMDIydjIuNDU5M2MwIDAuNTQ5NCAwLjQ0MzAxIDAuOTk1MyAwLjk5MTI4IDF6IiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9ImN1cnJlbnRDb2xvciIgZmlsbC1ydWxlPSJldmVub2RkIj48L3BhdGg+PC9zdmc+"
-        try:
-            from open_webui.models.models import Models
+        self.icon = (
+            "data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQi"
+            "IHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgY2xhc3M9ImgtWzE4cHldIHctWzE4"
+            "cHldIj48cGF0aCBkPSJtMTIgM2MtMy41ODUgMC02LjUgMi45MjI1LTYuNSA2LjUzODUgMCAyLjI4"
+            "MjYgMS4xNjIgNC4yOTEzIDIuOTI0OCA1LjQ2MTVoNy4xNTA0YzEuNzYyOC0xLjE3MDIgMi45MjQ4"
+            "LTMuMTc4OSAyLjkyNDgtNS40NjE1IDAtMy42MTU5LTIuOTE1LTYuNTM4NS02LjUtNi41Mzg1em0y"
+            "Ljg2NTMgMTRoLTUuNzMwNnYxaDUuNzMwNnYtMXptLTEuMTMyOSAzSC03LjQ2NDhjMC4zNDU4IDAu"
+            "NTk3OCAwLjk5MjEgMSAxLjczMjQgMXMxLjM4NjYtMC40MDIyIDEuNzMyNC0xem0tNS42MDY0IDBj"
+            "MC40NDQwMyAxLjcyNTIgMi4wMTAxIDMgMy44NzQgM3MzLjQzLTEuMjc0OCAzLjg3NC0zYzAuNTQ4"
+            "My0wLjAwNDcgMC45OTEzLTAuNDUwNiAwLjk5MTMtMXYtMi40NTkzYzIuMTk2OS0xLjU0MzEgMy42"
+            "MzQ3LTQuMTA0NSAzLjYzNDctNy4wMDIyIDAtNC43MTA4LTMuODAwOC04LjUzODUtOC41LTguNTM4"
+            "NS00LjY5OTIgMC04LjUgMy44Mjc2LTguNSA4LjUzODUgMCAyLjg5NzcgMS40Mzc4IDUuNDU5MSAz"
+            "LjYzNDcgNy4wMDIydjIuNDU5M2MwIDAuNTQ5NCAwLjQ0MzAxIDAuOTk1MyAwLjk5MTI4IDF6IiBj"
+            "bGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9ImN1cnJlbnRDb2xvciIgZmlsbC1ydWxlPSJldmVub2Rk"
+            "Ij48L3BhdGg+PC9zdmc+"
+        )
 
-            self.model_info = Models.get_model_by_id(self.valves.MODEL)
-        except Exception:
-            self.model_info = None
 
     async def inlet(
         self,
         body: dict,
         __metadata__: dict | None = None,
-        ) -> dict:
+    ) -> dict:
         body["model"] = self.valves.MODEL
-        effort = self.valves.REASONING_EFFORT
-        if effort != "not set":
-            body["reasoning_effort"] = effort
+        if self.valves.REASONING_EFFORT != "not set":
+            body["reasoning_effort"] = self.valves.REASONING_EFFORT
 
-        if __metadata__ is not None and self.model_info:
+        if __metadata__ is not None:
             try:
-                __metadata__["model"] = self.model_info.model_dump()
+                from open_webui.models.models import Models
+
+                __metadata__["model"] = Models.get_model_by_id(
+                    self.valves.MODEL
+                ).model_dump()
             except Exception:
                 pass
 
-        chat_id = (__metadata__ or {}).get("chat_id")
-        message_id = (__metadata__ or {}).get("message_id")
-
-        if chat_id and message_id:
-            try:
-                from open_webui.models.chats import Chats
-
-                Chats.upsert_message_to_chat_by_id_and_message_id(
-                    chat_id,
-                    message_id,
-                    {"model": self.valves.MODEL},
-                )
-            except Exception:
-                pass
-
+        meta = __metadata__ or {}
+        self._persist_model(meta.get("chat_id"), meta.get("message_id"))
         return body
 
     async def outlet(
@@ -68,20 +68,8 @@ class Filter:
     ) -> dict:
         """Persist the rerouted model so the UI reflects it."""
 
-        chat_id = (__metadata__ or {}).get("chat_id")
-        message_id = (__metadata__ or {}).get("message_id")
-
-        if chat_id and message_id:
-            try:
-                from open_webui.models.chats import Chats
-
-                Chats.upsert_message_to_chat_by_id_and_message_id(
-                    chat_id,
-                    message_id,
-                    {"model": self.valves.MODEL},
-                )
-            except Exception:
-                pass
+        meta = __metadata__ or {}
+        self._persist_model(meta.get("chat_id"), meta.get("message_id"))
 
         messages = body.get("messages")
         if isinstance(messages, list) and messages:
@@ -91,3 +79,14 @@ class Filter:
                 last_msg.setdefault("modelName", self.valves.MODEL)
 
         return body
+
+    def _persist_model(self, chat_id: str | None, message_id: str | None) -> None:
+        if chat_id and message_id:
+            try:
+                from open_webui.models.chats import Chats
+
+                Chats.upsert_message_to_chat_by_id_and_message_id(
+                    chat_id, message_id, {"model": self.valves.MODEL}
+                )
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- fix reason filter metadata bug by fetching model info at runtime
- centralize history persistence
- update changelog

## Testing
- `pre-commit run --files functions/filters/reason_toggle_filter/reason_toggle_filter.py functions/filters/reason_toggle_filter/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68485d551f94832eb620a7bcdac4cb2d