### PR TITLE
Add message persistence probe pipe

### DIFF
--- a/.tests/test_message_persistence_probe.py
+++ b/.tests/test_message_persistence_probe.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+
+def test_importable():
+    mod = import_module('functions.pipes.message_persistence_probe.message_persistence_probe')
+    assert hasattr(mod, 'Pipe')

--- a/functions/pipes/message_persistence_probe/README.md
+++ b/functions/pipes/message_persistence_probe/README.md
@@ -1,0 +1,8 @@
+# Message Persistence Probe
+
+A simple test pipeline that inserts an extra assistant message into the chat history.
+Use it to verify whether database writes performed inside a pipe remain after the
+middleware finishes processing a request.
+
+The pipe adds a placeholder message referencing the current message ID. It then
+returns a short confirmation string.

--- a/functions/pipes/message_persistence_probe/message_persistence_probe.py
+++ b/functions/pipes/message_persistence_probe/message_persistence_probe.py
@@ -1,0 +1,63 @@
+"""
+title: Message Persistence Probe
+id: message_persistence_probe
+author: OpenAI Codex
+description: Insert a test assistant message into the chat history.
+version: 0.1.0
+license: MIT
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Awaitable, Callable
+
+from open_webui.models.chats import Chats
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: dict[str, Any],
+        __metadata__: dict[str, Any],
+        __event_emitter__: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        __user__: dict[str, Any] | None = None,
+        __request__: Any | None = None,
+        __files__: list[dict[str, Any]] | None = None,
+        __tools__: dict[str, Any] | None = None,
+    ) -> str:
+        """Insert a placeholder assistant message and return a confirmation."""
+
+        chat_id = __metadata__.get("chat_id")
+        parent_id = __metadata__.get("message_id")
+        if not chat_id or not parent_id:
+            return "No chat context provided"
+
+        new_id = str(uuid.uuid4())
+        timestamp = int(time.time() * 1000)
+        message = {
+            "id": new_id,
+            "parentId": parent_id,
+            "childrenIds": [],
+            "role": "assistant",
+            "content": "This is a persistence probe message.",
+            "timestamp": timestamp,
+        }
+
+        Chats.upsert_message_to_chat_by_id_and_message_id(chat_id, new_id, message)
+        Chats.upsert_message_to_chat_by_id_and_message_id(
+            chat_id, parent_id, {"childrenIds": [new_id]}
+        )
+
+        if __event_emitter__:
+            await __event_emitter__(
+                {
+                    "type": "status",
+                    "update_db": True,
+                    "message_id": new_id,
+                    "event": {"content": "probe stored"},
+                }
+            )
+
+        return f"Inserted probe message {new_id}"


### PR DESCRIPTION
## Summary
- add `message_persistence_probe` pipeline to test if DB writes persist
- document probe pipeline
- add import test

## Testing
- `pre-commit run --files functions/pipes/message_persistence_probe/message_persistence_probe.py functions/pipes/message_persistence_probe/README.md .tests/test_message_persistence_probe.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684936b3de5c832e9fb5d3542eb70ad6