### PR TITLE
Implement persistence helpers for responses manifold

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.
+- Implemented database helper functions for new response item schema.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.


### PR DESCRIPTION
## Summary
- add ULID generation and encoded ID utilities
- implement item persistence helpers using new schema
- update history reconstruction helper
- note new helper functions in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a2b428ad8832e9ed5798daad67fb9