### PR TITLE
Implement helper utilities for OpenAI response items

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.
 - Implemented database helper functions for new response item schema.
+- Refined item encoding and lookup helpers.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.


### PR DESCRIPTION
## Summary
- refine `openai_responses_manifold` helper docstrings
- expand CHANGELOG entry for helper updates

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md .tests/test_openai_responses_manifold.py`

------
https://chatgpt.com/codex/tasks/task_e_684a2d678cd8832eb3dec1b35ee52d49