### PR TITLE
Implement encoded ID helper for response items

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added helper utilities for zero-width encoded item persistence.
 - Implemented database helper functions for new response item schema.
 - Refined item encoding and lookup helpers.
+- Added `add_openai_response_items_and_get_encoded_ids` to return
+  zero-width encoded references when persisting items.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.


### PR DESCRIPTION
## Summary
- add `add_openai_response_items_and_get_encoded_ids` helper to persist items and return zero-width encoded IDs
- note new helper in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a30953f5c832eb2d9988cd4930533