### PR TITLE
Update helpers for response item persistence

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added `add_openai_response_items_and_get_encoded_ids` to return
   zero-width encoded references when persisting items.
 - Filtered persisted item lookups by model ID when rebuilding history.
+- Fixed extraction logic for consecutive encoded IDs.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.


### PR DESCRIPTION
## Summary
- fix helper functions for encoded id extraction
- document fix in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a34268144832eafe1f2bce73c9781