### PR TITLE
Improve response item helpers

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
   zero-width encoded references when persisting items.
 - Filtered persisted item lookups by model ID when rebuilding history.
 - Fixed extraction logic for consecutive encoded IDs.
+- Improved `build_openai_input` to handle system messages and
+  preserve message whitespace.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.


### PR DESCRIPTION
## Summary
- refine build_openai_input helper to keep system messages and whitespace
- minor cleanup in encode_id
- update changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a35c01928832ea93226dcb7e81161