### PR TITLE
Refine response item helpers

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -12,8 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
   zero-width encoded references when persisting items.
 - Filtered persisted item lookups by model ID when rebuilding history.
 - Fixed extraction logic for consecutive encoded IDs.
-- Improved `build_openai_input` to handle system messages and
-  preserve message whitespace.
+- Adjusted `build_openai_input` to drop system prompts entirely since
+  they are passed via the `instructions` parameter. Message whitespace
+  is still preserved.
 
 ## [0.8.5] - 2025-06-10
 - Added `TRUNCATION` valve to configure automatic truncation behaviour.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -1543,15 +1543,8 @@ def build_openai_input(
         role = message.get("role", "assistant")
         content = message.get("content", "")
 
+        # System prompts are passed separately via the `instructions` field
         if role == "system":
-            if content:
-                openai_input.append(
-                    {
-                        "type": "message",
-                        "role": "system",
-                        "content": [{"type": "input_text", "text": content}],
-                    }
-                )
             continue
 
         if role == "user":


### PR DESCRIPTION
## Summary
- tweak CHANGELOG for helper helpers
- ignore system prompts when converting messages back to OpenAI format

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a381df7a4832eb0f9207f1143ed87