### PR TITLE
Fix item model filtering

### DIFF
--- a/.tests/test_openai_responses_manifold.py
+++ b/.tests/test_openai_responses_manifold.py
@@ -38,3 +38,45 @@ def test_split_and_extract_ids():
     assert segments[2]["type"] == "encoded_id"
     assert segments[2]["id"] == ids[1]
     assert segments[3]["type"] == "text"
+
+
+def test_item_persistence_roundtrip(monkeypatch):
+    mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
+
+    storage = {}
+
+    class DummyChatModel:
+        def __init__(self, chat=None):
+            self.chat = chat or {"history": {"messages": {}}}
+
+    class DummyChats:
+        @staticmethod
+        def get_chat_by_id(cid):
+            return DummyChatModel(storage.get(cid, {"history": {"messages": {}}}))
+
+        @staticmethod
+        def update_chat_by_id(cid, chat):
+            storage[cid] = chat
+            return DummyChatModel(chat)
+
+    monkeypatch.setattr(mod, "Chats", DummyChats)
+
+    encoded = mod.add_openai_response_items_and_get_encoded_ids(
+        "c1",
+        "m1",
+        [{"type": "function_call", "name": "calc", "arguments": "{}"}],
+        "openai_responses.gpt-4o",
+    )
+    assert encoded  # id encoded
+    stored_id = mod.extract_encoded_ids(encoded)[0]
+    assert (
+        storage["c1"]["openai_responses_pipe"]["items"][stored_id]["model"]
+        == "openai_responses.gpt-4o"
+    )
+
+    messages = [{"role": "assistant", "content": encoded + "result"}]
+    result = mod.build_openai_input(messages, "c1", model_id="openai_responses.gpt-4o")
+
+    assert result[0]["type"] == "function_call"
+    assert result[1]["type"] == "message"
+    assert result[1]["content"][0]["text"] == "result"

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Embedded zero-width encoded IDs during streaming and non-streaming flows.
 - Persisted each output item immediately and yielded the encoded reference.
 - Rebuilt chat history using `build_openai_input` for accurate ordering.
+- Stored full model ID for each item and stripped prefix only when filtering.
 
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -1464,8 +1464,10 @@ def fetch_items_by_ids(
         item = items_store.get(item_id)
         if not item:
             continue
-        if base_model and item.get("model") != base_model:
-            continue
+        if base_model:
+            item_base = item.get("model", "").removeprefix("openai_responses.")
+            if item_base != base_model:
+                continue
         lookup[item_id] = item.get("payload", {})
     return lookup
 


### PR DESCRIPTION
## Summary
- keep full model ID when persisting response items
- strip prefix when filtering fetched items
- verify prefix is stored in regression test

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md .tests/test_openai_responses_manifold.py`

------
https://chatgpt.com/codex/tasks/task_e_684a41d907b0832e96331d49cc5720cd