### PR TITLE
Fix reasoning details markup

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2025-06-15
+- Fixed `<details>` markup for reasoning summaries to match WebUI expectations.
+- `build_openai_input` now filters items using the full `model_id`.
+
 ## [0.8.7] - 2025-06-13
 - Embedded zero-width encoded IDs during streaming and non-streaming flows.
 - Persisted each output item immediately and yielded the encoded reference.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.7
+version: 0.8.8
 license: MIT
 requirements: orjson
 """
@@ -505,7 +505,7 @@ class Pipe:
 
                             # 4) Build a minimal snippet (omit type="reasoning")
                             snippet = (
-                                f"<details type=\"{__name__}.reasoning\" done=\"false\">\n"
+                                "<details type=\"reasoning\" done=\"false\">\n"
                                 f"<summary>🧠{latest_title}</summary>\n"
                                 f"{all_text}\n"
                                 "</details>"
@@ -582,8 +582,8 @@ class Pipe:
                                 all_text += "\n\n --- \n\n"
 
                                 final_snippet = (
-                                    f'<details type=\"{__name__}.reasoning\" done="true">\n'
-                                    f"<summary>Done thinking!</summary>\n"
+                                    '<details type="reasoning" done="true">\n'
+                                    "<summary>Done thinking!</summary>\n"
                                     f"{all_text}\n"
                                     "</details>"
                                 )
@@ -1456,18 +1456,14 @@ def fetch_items_by_ids(
     if not chat_model:
         return {}
 
-    base_model = model_id.removeprefix("openai_responses.") if model_id else None
-
     items_store = chat_model.chat.get("openai_responses_pipe", {}).get("items", {})
     lookup: Dict[str, Dict[str, Any]] = {}
     for item_id in item_ids:
         item = items_store.get(item_id)
         if not item:
             continue
-        if base_model:
-            item_base = item.get("model", "").removeprefix("openai_responses.")
-            if item_base != base_model:
-                continue
+        if model_id and item.get("model") != model_id:
+            continue
         lookup[item_id] = item.get("payload", {})
     return lookup
 


### PR DESCRIPTION
## Summary
- tweak reasoning summary `<details>` attributes
- filter stored items using the full model id
- bump OpenAI Responses Manifold version to 0.8.8 and update changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684a473ae570832eab7feee9df5556f0