### PR TITLE
Fix reasoning tag markup

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2025-06-11
+- Restored unique `<details>` tag for reasoning summaries and added a leading newline for compatibility.
+
 ## [0.8.7] - 2025-06-13
 - Embedded zero-width encoded IDs during streaming and non-streaming flows.
 - Persisted each output item immediately and yielded the encoded reference.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.7
+version: 0.8.8
 license: MIT
 requirements: orjson
 """
@@ -505,7 +505,7 @@ class Pipe:
 
                             # 4) Build a minimal snippet (omit type="reasoning")
                             snippet = (
-                                f"<details type=\"{__name__}.reasoning\" done=\"false\">\n"
+                                f"\n<details type=\"{__name__}.reasoning\" done=\"false\">\n"
                                 f"<summary>🧠{latest_title}</summary>\n"
                                 f"{all_text}\n"
                                 "</details>"
@@ -582,8 +582,8 @@ class Pipe:
                                 all_text += "\n\n --- \n\n"
 
                                 final_snippet = (
-                                    f'<details type=\"{__name__}.reasoning\" done="true">\n'
-                                    f"<summary>Done thinking!</summary>\n"
+                                    f"\n<details type=\"{__name__}.reasoning\" done=\"true\">\n"
+                                    "<summary>Done thinking!</summary>\n"
                                     f"{all_text}\n"
                                     "</details>"
                                 )


### PR DESCRIPTION
## Summary
- fix reasoning `<details>` tag markup in `openai_responses_manifold`
- document update in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_684a4df4d46c832eaeab513eab33cfff