### PR TITLE
Update completions API docs

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Rebuilt chat history using `build_openai_input` for accurate ordering.
 - Stored full model ID for each item and stripped prefix only when filtering.
 
+## [0.8.8] - 2025-06-14
+- Renamed helper functions for clarity and maintainability.
+- Simplified rebuilding of input history.
+- Added support for custom parameters from Open WebUI.
+  - `max_tokens` now maps to `max_output_tokens`.
+  - Additional parameters are passed through for future compatibility.
+
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.
 - Implemented database helper functions for new response item schema.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -24,6 +24,7 @@
 | Usage Pass-through | ✅ GA | 2025-06-04 | Tokens and usage aggregated and passed through to Open WebUI GUI. |
 | Response item persistence | ✅ GA | 2025-06-11 | Stores function calls and other non-message items using zero-width encoded IDs. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
+| Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (e.g., upload and modify). |
 | File upload / file search tool | 🕒 Backlog | 2025-06-03 | Roadmap item. |
@@ -38,6 +39,7 @@
 - **Pseudo-models**: `o3-mini-high` / `o4-mini-high` – alias for `o3-mini` / `o4-mini` with high reasoning effort.
 - **Debug logging**: Set `LOG_LEVEL` to `debug` for in‑message log details. Can be set globally or per user.
 - **Truncation strategy**: Control with the `TRUNCATION` valve. Default `auto` drops middle context when the request exceeds the window; `disabled` fails with a 400 error. Works with each model's `max_completion_tokens` limit.
+- **Custom parameters**: Pass extra OpenAI settings via Open WebUI's "Custom Parameters" feature. `max_tokens` becomes `max_output_tokens` automatically.
 
 ### Tested models
 The manifold should work with any model that supports the responses API. Confirmed with:


### PR DESCRIPTION
## Summary
- document custom parameter passthrough in OpenAI Responses Manifold README
- record helper renames and new parameter behaviour in changelog
- sync tests with renamed helper utilities

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md .tests/test_openai_responses_manifold.py`

------
https://chatgpt.com/codex/tasks/task_e_684c76615750832e81dd62a9896e2fc4