### PR TITLE
Fix streaming reasoning block flow

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added support for custom parameters from Open WebUI.
   - `max_tokens` now maps to `max_output_tokens`.
   - Additional parameters are passed through for future compatibility.
+- Refined reasoning block streaming for safe token ordering.
 
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.


### PR DESCRIPTION
## Summary
- refactor `_run_streaming_loop` to delay encoded token emission until safe points
- add `StreamSectionManager` helper for reasoning block tracking
- update version to 0.8.8 and changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684ccf2eec70832ebc84661a7c9b864c