### PR TITLE
Fix newline handling in Responses streaming

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Replaced streaming loop with a single-flag newline injector for
   predictable token placement.
 
+## [0.8.9] - 2025-06-14
+- Fixed newline injection for reasoning snippets to preserve Markdown rendering.
+
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.
 - Implemented database helper functions for new response item schema.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.8
+version: 0.8.9
 license: MIT
 requirements: orjson
 """
@@ -526,6 +526,14 @@ class Pipe:
 
         need_newline = False
 
+        def flush_and_yield(text: str):
+            """Yield text after inserting a pending newline if needed."""
+            nonlocal need_newline
+            if need_newline:
+                yield "\n"
+                need_newline = False
+            yield text
+
         try:
             for loop_idx in range(valves.MAX_TOOL_CALL_LOOPS):
                 final_response: dict[str, Any] | None = None
@@ -539,11 +547,9 @@ class Pipe:
                     if etype == "response.output_text.delta":
                         delta = event.get("delta", "")
                         if delta:
-                            if need_newline:
-                                yield "\n"
-                                need_newline = False
                             final_output.write(delta)
-                            yield delta
+                            async for chunk in flush_and_yield(delta):
+                                yield chunk
                         continue
 
                     if etype == "response.reasoning_summary_text.delta":
@@ -591,7 +597,8 @@ class Pipe:
                                 f'<details type="{__name__}.reasoning" done="true">\n'
                                 f"<summary>Done thinking!</summary>\n{parts}\n</details>"
                             )
-                            yield snippet
+                            async for chunk in flush_and_yield(snippet):
+                                yield chunk
                             reasoning_map.clear()
                         continue
 


### PR DESCRIPTION
## Summary
- fix newline injection for reasoning snippets using a flush helper
- update `openai_responses_manifold.py` version to 0.8.9
- document fix in the changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684ce053d6f0832eaffc0805eb119448