### PR TITLE
Fix blank line after reasoning block

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
+- Fixed blank line after reasoning block by delaying encoded ID emission.
 
 ## [0.8.7] - 2025-06-13
 - Embedded zero-width encoded IDs during streaming and non-streaming flows.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -577,6 +577,7 @@ class Pipe:
                         item = event.get("item", {})
                         item_type = item.get("type", "")
 
+                        token = None
                         if valves.PERSIST_TOOL_RESULTS and item_type != "message":
                             token = persist_openai_response_items(
                                 metadata.get("chat_id"),
@@ -584,9 +585,6 @@ class Pipe:
                                 [item],
                                 openwebui_model,
                             )
-                            if token:
-                                yield token
-                                need_newline = True
 
                         if item_type == "reasoning":
                             parts = "\n\n --- \n\n".join(
@@ -598,7 +596,15 @@ class Pipe:
                             )
                             for chunk in _emit_visible(snippet):
                                 yield chunk
+                            if token:
+                                yield token
+                                need_newline = True
                             reasoning_map.clear()
+                            continue
+
+                        if token:
+                            yield token
+                            need_newline = True
                         continue
 
                     if etype == "response.completed":


### PR DESCRIPTION
## Summary
- ensure tokens for reasoning blocks emit after the closing snippet
- document the fix in the changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684ce9ffb28c832ebba77d2291b7323f