### PR TITLE
Fix newline after reasoning block

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.
 
+## [0.8.10] - 2025-06-16
+- Prevented extra newline after reasoning block by stripping leading newlines
+  before injecting the separator.
+
 ## [0.8.7] - 2025-06-13
 - Embedded zero-width encoded IDs during streaming and non-streaming flows.
 - Persisted each output item immediately and yielded the encoded reference.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.9
+version: 0.8.10
 license: MIT
 requirements: orjson
 """
@@ -529,6 +529,7 @@ class Pipe:
         def _emit_visible(chunk: str):
             nonlocal need_newline
             if need_newline:
+                chunk = chunk.lstrip("\n")
                 yield "\n"
                 need_newline = False
             yield chunk


### PR DESCRIPTION
## Summary
- prevent multiple newline injection by stripping leading newlines when emitting chunks
- bump `openai_responses_manifold` version to `0.8.10`
- document the fix in the changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_684cefc1185c832ebbd82e4d13da7c6c