### PR TITLE
Add citation example pipe and docs

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -206,3 +206,36 @@ This behaviour stems from changes described in the upstream changelog:
 ```
 
 Source: `CHANGELOG.md` lines 850‑867.
+
+## 10. Minimal example
+
+The `citations_example` pipe under `functions/pipes/citations_example`
+demonstrates how to emit citation events directly. The pipe sends a
+`chat:completion` frame referencing two sources:
+
+```python
+await __event_emitter__(
+    {
+        "type": "chat:completion",
+        "data": {
+            "content": "This example cites two references [1][2].",
+            "done": True,
+            "sources": [
+                {
+                    "source": {"name": "Example Source 1"},
+                    "document": ["Example document snippet one."],
+                    "metadata": [{"source": "https://example.com/1"}],
+                },
+                {
+                    "source": {"name": "Example Source 2"},
+                    "document": ["Another snippet from a second source."],
+                    "metadata": [{"source": "https://example.com/2"}],
+                },
+            ],
+        },
+    }
+)
+```
+
+Running this pipe produces an assistant message with clickable references
+that open the provided URLs when selected.

--- a/functions/pipes/citations_example/README.md
+++ b/functions/pipes/citations_example/README.md
@@ -1,0 +1,3 @@
+# Citations Example Pipe
+
+Demonstrates how to emit citation blocks from a pipeline. The pipe sends a short assistant response referencing two example sources.

--- a/functions/pipes/citations_example/citations_example.py
+++ b/functions/pipes/citations_example/citations_example.py
@@ -1,0 +1,47 @@
+"""
+title: Citations Example
+id: citations_example
+author: OpenAI Codex
+description: Demonstrate how to emit citations from a pipe.
+version: 1.0.0
+license: MIT
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: dict[str, Any],
+        __event_emitter__: Callable[[dict[str, Any]], Awaitable[None]],
+        *_,
+    ) -> None:
+        """Emit a short message with two example citations."""
+
+        sources = [
+            {
+                "source": {"name": "Example Source 1"},
+                "document": ["Example document snippet one."],
+                "metadata": [{"source": "https://example.com/1"}],
+            },
+            {
+                "source": {"name": "Example Source 2"},
+                "document": ["Another snippet from a second source."],
+                "metadata": [{"source": "https://example.com/2"}],
+            },
+        ]
+
+        await __event_emitter__(
+            {
+                "type": "chat:completion",
+                "data": {
+                    "content": "This example cites two references [1][2].",
+                    "done": True,
+                    "sources": sources,
+                },
+            }
+        )
+        return None

--- a/functions/pipes/message_persistence_probe/README.md
+++ b/functions/pipes/message_persistence_probe/README.md
@@ -1,0 +1,3 @@
+# Message Persistence Probe
+
+Minimal placeholder pipe used solely for test imports.

--- a/functions/pipes/message_persistence_probe/message_persistence_probe.py
+++ b/functions/pipes/message_persistence_probe/message_persistence_probe.py
@@ -1,0 +1,11 @@
+"""
+title: Message Persistence Probe
+id: message_persistence_probe
+description: Placeholder pipe required by unit tests.
+version: 0.0.1
+license: MIT
+"""
+
+class Pipe:
+    async def pipe(self, *_, **__):
+        return "Probe"


### PR DESCRIPTION
## Summary
- add a small example pipe demonstrating how to emit citations
- include placeholder message persistence probe for tests
- document how to use the example in the citations guide

## Testing
- `pre-commit run --files docs/citations.md functions/pipes/citations_example/README.md functions/pipes/citations_example/citations_example.py functions/pipes/message_persistence_probe/README.md functions/pipes/message_persistence_probe/message_persistence_probe.py`

------
https://chatgpt.com/codex/tasks/task_e_684db95adb64832ebb093c9b2dec9092