### PR TITLE
Fix multi message example bubble creation

### DIFF
--- a/functions/pipes/multi_message_bubble_example/README.md
+++ b/functions/pipes/multi_message_bubble_example/README.md
@@ -1,3 +1,7 @@
 # Multi-Message Bubble Example
 
 Demonstrates how a pipe can emit more than one assistant message in response to a single user prompt.
+
+Open WebUI only renders messages that already exist in the chat's history. After
+creating an additional message row you must broadcast a `chat:message` event so
+the UI learns about it. Without this event the extra row will remain invisible.


### PR DESCRIPTION
## Summary
- notify UI about second message with a `chat:message` event
- document the need to broadcast when creating extra message rows

## Testing
- `pre-commit run --files functions/pipes/multi_message_bubble_example/multi_message_bubble_example.py functions/pipes/multi_message_bubble_example/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6850830d867c832e8cc5ad9c9735ab9d