### PR TITLE
Update multi message example pipe

### DIFF
--- a/functions/pipes/multi_message_bubble_example/README.md
+++ b/functions/pipes/multi_message_bubble_example/README.md
@@ -1,6 +1,8 @@
 # Multi-Message Bubble Example
 
 Demonstrates how a pipe can emit more than one assistant message in response to a single user prompt.
+After the first response this example prompts the user to confirm whether a second
+message should be displayed.
 
 Open WebUI only renders messages that already exist in the chat's history. After
 creating an additional message row you must broadcast a `chat:message` event so


### PR DESCRIPTION
## Summary
- prompt the user before sending a second message bubble
- document confirmation behaviour in README

## Testing
- `pre-commit run --files functions/pipes/multi_message_bubble_example/multi_message_bubble_example.py functions/pipes/multi_message_bubble_example/README.md .tests/test_multi_message_bubble_example.py`

------
https://chatgpt.com/codex/tasks/task_e_68508786aed8832eac31ea71773aa2be