### PR TITLE
Refactor openai_responses manifold markers

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.8.10] - 2025-06-16
 - Replaced zero-width item ID encoding with empty Markdown links.
+- Introduced v1 markers with model metadata and removed legacy helpers.
 
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -22,7 +22,7 @@
 | Task model support | ✅ GA | 2025-06-06 | Use model as [Open WebUI External Task Model](https://docs.openwebui.com/tutorials/tips/improve-performance-local/) (title generation, tag generation, etc.). |
 | Streaming responses (SSE) | ✅ GA | 2025-06-04 | Real-time, partial output streaming for text and tool events. |
 | Usage Pass-through | ✅ GA | 2025-06-04 | Tokens and usage aggregated and passed through to Open WebUI GUI. |
-| Response item persistence | ✅ GA | 2025-06-11 | Stores function calls and other non-message items using invisible IDs in empty links. |
+| Response item persistence | ✅ GA | 2025-06-16 | Stores function calls and other non-message items using invisible IDs in empty links. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |


### PR DESCRIPTION
## Summary
- switch to v1 markers for OpenAI response items
- update persistence utilities and tests
- document marker change

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py .tests/test_openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6850ce2a7fb8832e9d981f2efee247d2