### PR TITLE
Fix metadata lookup in OpenAI Responses manifold

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Replaced zero-width item ID encoding with empty Markdown links.
 - Introduced v1 markers with model metadata and removed legacy helpers.
 
+## [0.8.11] - 2025-06-17
+- Fixed crash in non-streaming loop when metadata lacked a model ID.
+
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.10
+version: 0.8.11
 license: MIT
 requirements: orjson
 """
@@ -677,7 +677,7 @@ class Pipe:
                                 metadata.get("chat_id"),
                                 metadata.get("message_id"),
                                 [item],
-                                metadata.get("model").get("id"),
+                                metadata.get("model", {}).get("id"),
                             )
                             final_output.write(marker)
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when metadata has no model
- bump OpenAI Responses manifold version to 0.8.11
- document fix in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6850d2678ad4832eb59954a6d519b10e