### PR TITLE
Add invisible item encoding for non-streamed responses

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [0.8.11] - 2025-06-17
 - Fixed crash in non-streaming loop when metadata lacked a model ID.
+- Added invisible link persistence for non-streaming responses.
 
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.


### PR DESCRIPTION
## Summary
- persist reasoning summaries and other non-message items when using the non-streaming loop
- document this behavior in the changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md .tests/test_openai_responses_manifold.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d44810d0832ebfff5868c7115bd8