### PR TITLE
Fix non-streaming message disappearance

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Fixed crash in non-streaming loop when metadata lacked a model ID.
 - Added invisible link persistence for non-streaming responses.
 
+## [0.8.12] - 2025-06-18
+- Fixed missing final message when streaming disabled by emitting the
+  complete text via `chat:completion`.
+
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.11
+version: 0.8.12
 license: MIT
 requirements: orjson
 """
@@ -747,14 +747,19 @@ class Pipe:
             )
             return ""
         finally:
-            if total_usage:
-                await self._emit_completion(event_emitter, usage=total_usage, done=True)
+            final_text = final_output.getvalue()
+            await self._emit_completion(
+                event_emitter,
+                content=final_text,
+                usage=total_usage if total_usage else None,
+                done=True,
+            )
 
             # Clear logs
             logs_by_msg_id.clear()
             SessionLogger.logs.pop(SessionLogger.session_id.get(), None)
 
-        return final_output.getvalue()
+        return final_text
     
     # 4.4 Task Model Handling
     async def _run_task_model_request(


### PR DESCRIPTION
## Summary
- emit the final response in `_run_nonstreaming_loop`
- bump `openai_responses_manifold` version to 0.8.12
- document fix in CHANGELOG

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6850dbdad0c8832eb37f0ceb7752e530