### PR TITLE
Add initial reasoning event for reasoning models

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Fixed missing final message when streaming disabled by emitting the
   complete text via `chat:completion`.
 
+## [0.8.13] - 2025-06-19
+- Emitted an initial reasoning block when using reasoning models to make
+  the interface show progress immediately.
+
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -7,7 +7,7 @@ funding_url: https://github.com/jrkropp/open-webui-developer-toolkit
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.12
+version: 0.8.13
 license: MIT
 requirements: orjson
 """
@@ -537,6 +537,16 @@ class Pipe:
         final_output = StringIO()
         total_usage: dict[str, Any] = {}
         status_emitted = False
+
+        if body.model in FEATURE_SUPPORT["reasoning"]:
+            snippet = (
+                f'<details type="{__name__}.reasoning" done="false">\n'
+                "<summary>🧠Thinking…</summary>\n"
+                "</details>"
+            )
+            if event_emitter:
+                await event_emitter({"type": "chat:completion", "data": {"content": snippet}})
+            yield ""
 
         try:
             for loop_idx in range(valves.MAX_TOOL_CALL_LOOPS):


### PR DESCRIPTION
## Summary
- send a placeholder reasoning block before the streaming loop starts
- bump version to `0.8.13`
- document the new behaviour in the changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517c993cf0832e8113348b8dd1ff91