### PR TITLE
Development

### DIFF
--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -124,8 +124,18 @@ class ResponsesBody(BaseModel):
         strict: bool = False,
     ) -> list[dict]:
         """
-        Merge *openwebui_tools* (__tools__) and *body_tools* (body['tools'])
-        into a single list of **canonical Responses‑API** tool definitions.
+        Normalise and merge:
+
+            __tools__  = {"id": {"spec": {"name": "calc", ...}}}
+            body.tools = [
+                {"name": "foo", ...},                     # completions API style
+                {"type":"function","name":"bar", ...}     # responses
+            ]
+
+        → [{"type":"function","name":"calc", ...}, ...]   # responses shape
+
+        Later duplicate names override earlier; __tools__ beats body.tools.
+        strict=True  ⇒ every prop required, extras banned, optionals nullable.
         """
 
         if not openwebui_tools and not body_tools:


### PR DESCRIPTION
This pull request refines the functionality of the `openai_responses_manifold.py` pipeline by improving the merging and normalization of tools, optimizing the streaming loop logic, and addressing minor redundancies. Below are the key changes grouped by their themes:

### Improvements to Tool Normalization and Merging:
* Updated the `transform_tools` function to provide a clearer and more detailed explanation of how `__tools__` and `body.tools` are normalized and merged into a single list. This includes specifying the output format and clarifying the precedence rules for duplicate names. A TODO comment was added to reconsider the precedence order.

### Optimizations in Streaming Logic:
* Added a safeguard in `_run_streaming_loop` to yield an empty string when no snippet is available, ensuring the stream remains active.
* Removed redundant code in `_run_streaming_loop` that yielded an empty string unnecessarily, streamlining the logic.

### Minor Adjustments:
* Adjusted the handling of `final_response` in `_run_streaming_loop` to avoid redundant extension of `body.input`. This ensures cleaner and more efficient processing of the response output.