### PR TITLE
Add MCP valve

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Fixed missing final message when streaming disabled by emitting the
   complete text via `chat:completion`.
 
+## [0.8.14] - 2025-06-23
+- Added experimental `MCP` valve for remote MCP server support.
+- Updated README with configuration instructions.
+
 ## [0.8.13] - 2025-06-19
 - Emitted an initial reasoning block when using reasoning models to make
   the interface show progress immediately.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -4,7 +4,7 @@
 > **Author:** [Justin Kropp](https://github.com/jrkropp)  
 > **License:** MIT
 
-⚠️ **Version 0.8.13 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
+⚠️ **Version 0.8.14 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
 
 ## Installation
 1. Copy `openai_responses_manifold.py` to your Open WebUI under **Admin Panel ▸ Functions**.
@@ -32,7 +32,7 @@
 | Computer use tool | 🕒 Backlog | 2025-06-03 | [OpenAI docs](https://platform.openai.com/docs/guides/tools-computer-use) |
 | Live conversational voice (Talk) | 🕒 Backlog | 2025-06-03 | Requires backend patching; design under consideration. |
 | Dynamic chat titles | 🕒 Backlog | 2025-06-03 | For progress/status indication during long tasks. |
-| MCP tool support | 🕒 Backlog | 2025-06-09 | Remote MCP servers via Responses API. [More info](https://platform.openai.com/docs/guides/tools-remote-mcp) |
+| MCP tool support | 🧪 Experimental | 2025-06-23 | Remote MCP servers via Responses API using the `MCP` valve. [More info](https://platform.openai.com/docs/guides/tools-remote-mcp) |
 
 
 ### Other Features
@@ -40,6 +40,15 @@
 - **Debug logging**: Set `LOG_LEVEL` to `debug` for in‑message log details. Can be set globally or per user.
 - **Truncation strategy**: Control with the `TRUNCATION` valve. Default `auto` drops middle context when the request exceeds the window; `disabled` fails with a 400 error. Works with each model's `max_completion_tokens` limit.
 - **Custom parameters**: Pass extra OpenAI settings via Open WebUI's "Custom Parameters" feature. `max_tokens` becomes `max_output_tokens` automatically.
+
+### MCP valve setup
+Set the `MCP` valve to a JSON object or array describing remote MCP servers. Each
+entry is appended to the OpenAI `tools` list with `type: "mcp"`. Example:
+
+```json
+[{"server_label": "deepwiki", "server_url": "https://mcp.deepwiki.com/mcp", "require_approval": "never"}]
+```
+This feature is experimental and subject to change.
 
 ### Tested models
 The manifold should work with any model that supports the responses API. Confirmed with:

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -6,7 +6,7 @@ author_url: https://github.com/jrkropp
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.13
+version: 0.8.14
 license: MIT
 """
 
@@ -18,7 +18,6 @@ from __future__ import annotations
 # Standard library, third-party, and Open WebUI imports
 # Standard library imports
 import asyncio
-from copy import deepcopy
 import datetime
 import inspect
 from io import StringIO
@@ -425,6 +424,13 @@ class Pipe:
             default=True,
             description="Persist tool call results across conversation turns. When disabled, tool results are not stored in the chat history.",
         )
+        MCP: Optional[str] = Field(
+            default=None,
+            description=(
+                "\U0001f9ea Experimental: JSON describing one or more MCP servers to "
+                "append to every request's tools array. Format may change."
+            ),
+        )
         USER_ID_FIELD: Literal["id", "email"] = Field(
             default="id",
             description=(
@@ -527,6 +533,20 @@ class Pipe:
                     "region": "BC",
                 }
             })
+
+        # Experimental MCP tool support
+        if valves.MCP:
+            responses_body.tools = responses_body.tools or []
+            try:
+                mcp_defs = json.loads(valves.MCP)
+                if isinstance(mcp_defs, dict):
+                    mcp_defs = [mcp_defs]
+                for spec in mcp_defs:
+                    if isinstance(spec, dict):
+                        tool = {"type": "mcp", **spec}
+                        responses_body.tools.append(tool)
+            except Exception as e:  # pragma: no cover - malformed config
+                self.logger.error("Invalid MCP valve: %s", e)
 
         # Check if tools are enabled but native function calling is disabled
         # If so, update the OpenWebUI model parameter to enable native function calling for future requests.


### PR DESCRIPTION
## Summary
- add MCP valve to the OpenAI Responses Manifold
- append configured MCP servers to OpenAI tools
- document MCP setup and bump version

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_685981ce9588832e86eb2f4e0eca7779