### PR TITLE
Update markers to v2 format

### DIFF
--- a/.tests/test_openai_responses_manifold.py
+++ b/.tests/test_openai_responses_manifold.py
@@ -14,21 +14,21 @@ def test_importable():
 def test_marker_roundtrip():
     mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
 
-    marker = mod.create_marker('function_call', ulid='01HX4Y2VW5VR2Z2HDQ5QY9REHB', model_id='gpt-4o')
+    marker = mod.create_marker('function_call', ulid='01HX4Y2VW5VR2Z2H', model_id='gpt-4o')
     parsed = mod.parse_marker(marker)
-    assert parsed['ulid'] == '01HX4Y2VW5VR2Z2HDQ5QY9REHB'
+    assert parsed['ulid'] == '01HX4Y2VW5VR2Z2H'
     assert parsed['item_type'] == 'function_call'
     assert parsed['metadata']['model'] == 'gpt-4o'
     wrapped = mod.wrap_marker(marker)
-    assert '\n\n[](' in wrapped and wrapped.endswith('\n\n')
+    assert wrapped.startswith('\n[openai_responses:v2:') and wrapped.endswith(']: #\n')
 
 
 def test_split_and_extract_markers():
     mod = import_module('functions.pipes.openai_responses_manifold.openai_responses_manifold')
 
     ids = [
-        "01HX4Y2VW5VR2Z2HDQ5QY9REHB",
-        "01HX4Y2VW6B091XE84F5G0Z8NF",
+        "01HX4Y2VW5VR2Z2H",
+        "01HX4Y2VW6B091XE",
     ]
     encoded = "".join(mod.wrap_marker(mod.create_marker('function_call', ulid=i)) for i in ids)
     content = f"prefix {encoded} suffix"
@@ -39,7 +39,7 @@ def test_split_and_extract_markers():
     segments = mod.split_text_by_markers(content)
     assert segments[0]["type"] == "text"
     assert segments[1]["type"] == "marker"
-    assert 'openai_responses:v1:function_call' in segments[1]['marker']
+    assert 'openai_responses:v2:function_call' in segments[1]['marker']
 
 
 def test_item_persistence_roundtrip(monkeypatch):
@@ -82,5 +82,5 @@ def test_item_persistence_roundtrip(monkeypatch):
     )
 
     assert result[0]["type"] == "function_call"
-    assert result[1]["type"] == "message"
+    assert result[1]["role"] == "assistant"
     assert result[1]["content"][0]["text"] == "result"

--- a/docs/responses_manifold.md
+++ b/docs/responses_manifold.md
@@ -36,6 +36,14 @@ OpenAI's API returns rich output items such as function calls, tool responses an
 
 Items are kept verbatim as delivered by the API. When history is rebuilt, these items are inserted before the assistant message that generated them. Because the data sits under its own key, vanilla WebUI installations ignore it gracefully.
 
+To reference these stored items, the manifold embeds invisible markers into the assistant's message content. Each marker uses a markdown comment of the form:
+
+```
+[openai_responses:v2:<item_type>:<16-char-id>?model=<model_id>]: #
+```
+
+The `item_type` corresponds to the OpenAI event type. These markers remain hidden in the UI but allow the pipeline to reconstruct the conversation with the exact items preserved.
+
 ## Encrypted Reasoning Tokens
 
 Reasoning models can include an `encrypted_content` field. The manifold stores this encrypted token with each response. OpenAI uses it to cache earlier reasoning steps so follow‑up requests are faster and require less context, improving both speed and quality. Models no longer need to reread their own explanations, giving them more budget for new reasoning in subsequent turns.

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -24,6 +24,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added experimental `MCP_SERVERS` valve to append remote MCP servers
   to the tools list.
 
+## [0.8.15] - 2025-06-27
+- Switched to 16-character ULIDs and `v2` comment markers.
+- Simplified ID generation with `secrets.choice`.
+- Updated regex and marker utilities for the new format.
+- Persisted items remain under `openai_responses_pipe` with shortened IDs.
+
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -1,7 +1,7 @@
 # OpenAI Responses Manifold
 **Enables advanced OpenAI features (function calling, web search, visible reasoning summaries, and more) directly in [Open WebUI](https://github.com/open-webui/open-webui).**
 
-⚠️ **Version 0.8.14 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
+⚠️ **Version 0.8.15 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
 
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**
@@ -31,7 +31,7 @@
 | Task model support | ✅ GA | 2025-06-06 | Use model as [Open WebUI External Task Model](https://docs.openwebui.com/tutorials/tips/improve-performance-local/) (title generation, tag generation, etc.). |
 | Streaming responses (SSE) | ✅ GA | 2025-06-04 | Real-time, partial output streaming for text and tool events. |
 | Usage Pass-through | ✅ GA | 2025-06-04 | Tokens and usage aggregated and passed through to Open WebUI GUI. |
-| Response item persistence | ✅ GA | 2025-06-17 | Persists items via newline-wrapped markers (v1) that embed type, ULID and metadata. |
+| Response item persistence | ✅ GA | 2025-06-27 | Persists items via newline-wrapped comment markers (v2) that embed type, 16-character ULIDs and metadata. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
@@ -314,7 +314,7 @@ The result of \(34234 \times \pi\) is approximately 107,549.28.
           "parentId": "933ea7dc-d9aa-4981-a447-b06846376136",
           "childrenIds": [],
           "role": "assistant",
-          "content": "[](openai_responses:v1:function_call:01HX4Y2VW5VR2Z2HDQ5QY9REHB?model=openai_responses.gpt-4o)[](openai_responses:v1:function_call_output:01HX4Y2VW6B091XE84F5G0Z8NF?model=openai_responses.gpt-4o)The result of \\( 34234 \\times \\pi \\) is approximately 107,549.28."
+          "content": "[openai_responses:v2:function_call:01HX4Y2VW5VR2Z2H?model=openai_responses.gpt-4o]: #\n[openai_responses:v2:function_call_output:01HX4Y2VW6B091XE?model=openai_responses.gpt-4o]: #\nThe result of \\(34234 \\times \\pi\\) is approximately 107,549.28."
           "model": "openai_responses.gpt-4o",
           "modelName": "OpenAI: GPT-4o ★★☆☆",
           "timestamp": 1749686545,

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -28,7 +28,6 @@ import os
 import re
 import sys
 import secrets
-import time
 from collections import defaultdict, deque
 from contextvars import ContextVar
 from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Literal, Optional, Union
@@ -1640,7 +1639,7 @@ CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 _SENTINEL = "[openai_responses:v2:"
 _RE = re.compile(
-    rf"\[openai_responses:v2:(?P<kind>[a-z0-9_]{2,30}):"
+    rf"\[openai_responses:v2:(?P<kind>[a-z0-9_]{{2,30}}):"
     rf"(?P<ulid>[A-Z0-9]{{{ULID_LENGTH}}})(?:\?(?P<query>[^\]]+))?\]:\s*#",
     re.I,
 )
@@ -1651,12 +1650,6 @@ def _qs(d: dict[str, str]) -> str:
 def _parse_qs(q: str) -> dict[str, str]:
     return dict(p.split("=", 1) for p in q.split("&")) if q else {}
 
-def _encode_base32(value: int, length: int) -> str:
-    chars = []
-    for _ in range(length):
-        chars.append(CROCKFORD_ALPHABET[value & 31])
-        value >>= 5
-    return "".join(reversed(chars))
 
 def generate_item_id() -> str:
     return ''.join(secrets.choice(CROCKFORD_ALPHABET) for _ in range(ULID_LENGTH))


### PR DESCRIPTION
## Summary
- bump docs to version 0.8.15
- document new invisible comment markers
- adjust regex for ULID length and remove unused helper
- update example database record
- refresh changelog and tests

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md docs/responses_manifold.md functions/pipes/openai_responses_manifold/CHANGELOG.md .tests/test_openai_responses_manifold.py`

------
https://chatgpt.com/codex/tasks/task_e_685f74b6a2f8832eb615d6b33fce0c4b