### PR TITLE
Fix changelog order and status emitter

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -4,25 +4,10 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.10] - 2025-06-16
-- Replaced zero-width item ID encoding with empty Markdown links.
-- Introduced v1 markers with model metadata and removed legacy helpers.
-
-## [0.8.11] - 2025-06-17
-- Fixed crash in non-streaming loop when metadata lacked a model ID.
-- Added invisible link persistence for non-streaming responses.
-
-## [0.8.12] - 2025-06-18
-- Fixed missing final message when streaming disabled by emitting the
-  complete text via `chat:completion`.
-
-## [0.8.13] - 2025-06-19
-- Emitted an initial reasoning block when using reasoning models to make
-  the interface show progress immediately.
-
-## [0.8.14] - 2025-06-23
-- Added experimental `MCP_SERVERS` valve to append remote MCP servers
-  to the tools list.
+## [0.8.16] - 2025-06-28
+- Fixed custom separator handling in `ExpandableStatusEmitter`.
+- Corrected `Tuple` import for type hints.
+- Sorted changelog entries chronologically.
 
 ## [0.8.15] - 2025-06-27
 - Switched to 16-character ULIDs and `v2` comment markers.
@@ -30,15 +15,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Updated regex and marker utilities for the new format.
 - Persisted items remain under `openai_responses_pipe` with shortened IDs.
 
+## [0.8.14] - 2025-06-23
+- Added experimental `MCP_SERVERS` valve to append remote MCP servers
+  to the tools list.
+
+## [0.8.13] - 2025-06-19
+- Emitted an initial reasoning block when using reasoning models to make
+  the interface show progress immediately.
+
+## [0.8.12] - 2025-06-18
+- Fixed missing final message when streaming disabled by emitting the
+  complete text via `chat:completion`.
+
+## [0.8.11] - 2025-06-17
+- Fixed crash in non-streaming loop when metadata lacked a model ID.
+- Added invisible link persistence for non-streaming responses.
+
+## [0.8.10] - 2025-06-16
+- Replaced zero-width item ID encoding with empty Markdown links.
+- Introduced v1 markers with model metadata and removed legacy helpers.
+
 ## [0.8.9] - 2025-06-15
 - Added helper to safely emit visible chunks after encoded IDs.
 - Fixed blank line after reasoning block by delaying encoded ID emission.
-
-## [0.8.7] - 2025-06-13
-- Embedded zero-width encoded IDs during streaming and non-streaming flows.
-- Persisted each output item immediately and yielded the encoded reference.
-- Rebuilt chat history using `build_openai_input` for accurate ordering.
-- Stored full model ID for each item and stripped prefix only when filtering.
 
 ## [0.8.8] - 2025-06-14
 - Renamed helper functions for clarity and maintainability.
@@ -49,6 +48,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Refined reasoning block streaming for safe token ordering.
 - Replaced streaming loop with a single-flag newline injector for
   predictable token placement.
+
+## [0.8.7] - 2025-06-13
+- Embedded zero-width encoded IDs during streaming and non-streaming flows.
+- Persisted each output item immediately and yielded the encoded reference.
+- Rebuilt chat history using `build_openai_input` for accurate ordering.
+- Stored full model ID for each item and stripped prefix only when filtering.
 
 ## [0.8.6] - 2025-06-12
 - Added helper utilities for zero-width encoded item persistence.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -32,6 +32,7 @@
 | Streaming responses (SSE) | ✅ GA | 2025-06-04 | Real-time, partial output streaming for text and tool events. |
 | Usage Pass-through | ✅ GA | 2025-06-04 | Tokens and usage aggregated and passed through to Open WebUI GUI. |
 | Response item persistence | ✅ GA | 2025-06-27 | Persists items via newline-wrapped comment markers (v2) that embed type, 16-character ULIDs and metadata. |
+| Expandable status output | ✅ GA | 2025-06-28 | Progress steps rendered via `<details>` tags. Use `ExpandableStatusEmitter` to add entries. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
@@ -53,6 +54,10 @@
 * **Debug logging**
   Set `LOG_LEVEL` to `debug` to include inline debug logs inside assistant messages.
   Can be configured **globally** via the pipe valve OR **per user** via user valve.
+
+* **Expandable status blocks**
+  Tool progress is shown using `<details type="openai_responses.expandable_status">` blocks.
+  The `ExpandableStatusEmitter` helper simplifies adding new steps programmatically.
 
 * **Truncation strategy**
   Use the `TRUNCATION` valve to control how long prompts are handled:

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -6,7 +6,7 @@ author_url: https://github.com/jrkropp
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.15
+version: 0.8.16
 license: MIT
 """
 
@@ -17,7 +17,7 @@ from __future__ import annotations
 # ─────────────────────────────────────────────────────────────────────────────
 # Standard library, third-party, and Open WebUI imports
 # Standard library imports
-from ast import Tuple
+from typing import Tuple
 import asyncio
 import datetime
 import inspect
@@ -1504,7 +1504,7 @@ class ExpandableStatusEmitter:
                     )
                     lines.append(indented_body)
 
-        joined = "\n".join(lines) + "\n\n---"
+        joined = "\n".join(lines) + f"\n\n{self.separator}"
 
         summary = self.items[-1][0].strip('*')
         summary_text = f"{self.summary_prefix}{summary}".strip()


### PR DESCRIPTION
## Summary
- fix Tuple import and make `ExpandableStatusEmitter` honour separator
- bump version to 0.8.16 and reorder CHANGELOG chronologically
- document expandable status emitter in README

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md functions/pipes/openai_responses_manifold/README.md`

------
https://chatgpt.com/codex/tasks/task_e_685f7dbf48a0832ea787d4742ebdbb99