### PR TITLE
Use simple comment format for hidden messages

### DIFF
--- a/functions/pipes/invisible_message_encoding_pipe/README.md
+++ b/functions/pipes/invisible_message_encoding_pipe/README.md
@@ -1,3 +1,10 @@
 # Invisible Message Encoding Pipe
 
-Encode user input invisibly in assistant responses and decode it from later messages.
+Persist a secret by embedding it in a hidden markdown comment:
+
+```markdown
+[my secret]: #
+```
+
+The text inside the brackets is hidden from normal Markdown rendering. Send
+another message later and the pipe will reveal it.


### PR DESCRIPTION
## Summary
- simplify the invisible message encoding pipe
- drop the versioned comment format and base64 helpers
- document the easier `[secret]: #` syntax

## Testing
- `pre-commit run --files functions/pipes/invisible_message_encoding_pipe/invisible_message_encoding_pipe.py functions/pipes/invisible_message_encoding_pipe/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6860011dd09c832eb42b325a21b6d63d