### PR TITLE
Refactor openai responses manifold tests

### DIFF
--- a/.tests/test_openai_responses_manifold.py
+++ b/.tests/test_openai_responses_manifold.py
@@ -52,25 +52,8 @@ def test_marker_roundtrip():
     assert segments[-1]["text"].strip().endswith("post")
 
 
-def test_persistence_fetch_and_input(monkeypatch):
-    storage = {}
-
-    class DummyChatModel:
-        def __init__(self, chat=None):
-            self.chat = chat or {"history": {"messages": {}}}
-
-    class DummyChats:
-        @staticmethod
-        def get_chat_by_id(cid):
-            return DummyChatModel(storage.get(cid, {"history": {"messages": {}}}))
-
-        @staticmethod
-        def update_chat_by_id(cid, chat):
-            storage[cid] = chat
-            return DummyChatModel(chat)
-
-    monkeypatch.setattr(mod, "Chats", DummyChats)
-
+def test_persistence_fetch_and_input(dummy_chats):
+    dummy_chats["c1"] = {"history": {"messages": {}}}
     marker1 = mod.persist_openai_response_items(
         "c1",
         "m1",


### PR DESCRIPTION
## Summary
- streamline `test_persistence_fetch_and_input`
- rely on shared `dummy_chats` fixture instead of local stubs

## Testing
- `pre-commit run --files .tests/test_openai_responses_manifold.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601042d144832e8bfc699803e55b3c