### PR TITLE
Add iframe example pipe

### DIFF
--- a/functions/pipes/iframe_example/README.md
+++ b/functions/pipes/iframe_example/README.md
@@ -1,0 +1,2 @@
+# IFrame Example
+A minimal pipe that yields an embedded iframe directly in the chat. The pipe streams an introductory line followed by a small iframe pointing to example.com.

--- a/functions/pipes/iframe_example/iframe_example.py
+++ b/functions/pipes/iframe_example/iframe_example.py
@@ -1,0 +1,33 @@
+"""
+title: IFrame Demo
+id: iframe_example
+author: OpenAI Codex
+description: Demonstrates yielding an iframe snippet directly to the chat.
+version: 1.0.0
+license: MIT
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator, Awaitable, Callable
+
+
+class Pipe:
+    async def pipe(
+        self,
+        body: dict[str, Any],
+        __event_emitter__: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        __metadata__: dict[str, Any] | None = None,
+        *_,
+    ) -> AsyncGenerator[str, None]:
+        """Stream a simple iframe example to the user."""
+
+        # Introductory text
+        yield "Here is a sample iframe rendered in the chat:\n\n"
+
+        # Inline HTML will be recognized by the frontend renderer
+        yield (
+            '<iframe src="https://example.com" ' 
+            'width="100%" height="200" ' 
+            'sandbox="allow-scripts allow-same-origin"></iframe>'
+        )


### PR DESCRIPTION
## Summary
- add an `iframe_example` pipe demonstrating how to yield an iframe snippet

## Testing
- `pre-commit run --files functions/pipes/iframe_example/iframe_example.py functions/pipes/iframe_example/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6865c841d27c832e89f494ec7cbca8af