### PR TITLE
Simplify deep research workflow

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Added Deep Research clarification and rewriting workflow.
 - Enabled support for o3-deep-research and o4-mini-deep-research models.
 
+## [0.8.19] - 2025-07-09
+- Refactored deep research flow and removed redundant helper functions.
+
 ## [0.8.17] - 2025-07-01
 - Added `ExpandableStatusIndicator` updates in the non-streaming loop.
 


### PR DESCRIPTION
## Summary
- refactor deep research phases in `openai_responses_manifold`
- remove unused helper and call `_run_task_model_request` directly
- bump version to 0.8.19
- document changes in CHANGELOG

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_686ed10b6ac0832e8d8799c42b3fb871