### PR TITLE
Simplify deep research confirm flow

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.8.20] - 2025-07-10
 - Simplified deep research logic via _run_deep_research_request.
 - Added valves for clarification and rewrite models.
+## [0.8.21] - 2025-07-11
+- Removed event_call confirmation step; rewrite draft is sent as a message.
+- Fixed input list bug causing 'str' object has no attribute 'extend'.
+- Clarify and rewrite models use web search tool when supported.
 ## [0.8.17] - 2025-07-01
 - Added `ExpandableStatusIndicator` updates in the non-streaming loop.
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -35,7 +35,7 @@
 | Expandable status output | ✅ GA | 2025-07-01 | Progress steps rendered via `<details>` tags. Use `ExpandableStatusEmitter` to add entries. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
-| Deep Search Support | ✅ GA | 2025-07-10 | Added valves for clarification and rewrite models. |
+| Deep Search Support | ✅ GA | 2025-07-11 | Simplified confirmation workflow; clarify/rewrite models use web search when supported. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (e.g., upload and modify). |
 | File upload / file search tool | 🕒 Backlog | 2025-06-03 | Roadmap item. |


### PR DESCRIPTION
## Summary
- return rewrite draft as normal message with confirm marker
- remove `event_call` confirmation step
- fix list handling for deep research sub-requests
- let clarify and rewrite models use web search if available
- document changes

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md functions/pipes/openai_responses_manifold/README.md`

------
https://chatgpt.com/codex/tasks/task_e_686edbccccc0832ea1739b98756a49fb