### PR TITLE
Improve deep research request logic

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Removed event_call confirmation step; rewrite draft is sent as a message.
 - Fixed input list bug causing 'str' object has no attribute 'extend'.
 - Clarify and rewrite models use web search tool when supported.
+## [0.8.22] - 2025-07-12
+- Improved Deep Research flow:
+  - Reused full chat history for clarify, rewrite and execute phases.
+  - Persisted rewritten prompt as a developer message and emitted confirm marker.
+  - Retrieved persisted prompt when executing the research request.
 ## [0.8.17] - 2025-07-01
 - Added `ExpandableStatusIndicator` updates in the non-streaming loop.
 


### PR DESCRIPTION
## Summary
- expand `_run_deep_research_request` docstring
- rebuild clarify/rewrite/deep research inputs from chat history
- persist rewritten prompt with confirm marker
- fetch persisted rewrite for execution
- bump version to 0.8.22

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_686ee7be873c832eb45f7a6c4165f995