### PR TITLE
Add citation style valve

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -1,6 +1,6 @@
 # 📚 Inline Citations in Open WebUI
 
-Open WebUI supports inline citations displayed as numbered references (e.g., `[1]`) within assistant responses. Users can click these references to view detailed source information.
+Open WebUI supports inline citations displayed as numbered references (e.g., `[1]`) within assistant responses. Users can click these references to view detailed source information. The `CITATION_STYLE` valve lets you show the source name instead of a number if desired.
 
 This guide covers:
 

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.8.19] - 2025-07-15
 - Added inline citation support with `[n]` markers and `citation` events.
 
+## [0.8.20] - 2025-07-16
+- Simplified citation handling by stripping markdown links when annotations
+  arrive.
+- Added `CITATION_STYLE` valve to control inline citation marker style
+  (`number` or `name`).
+
 ## [0.8.16] - 2025-06-28
 - Fixed custom separator handling in `ExpandableStatusEmitter`.
 - Corrected `Tuple` import for type hints.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -34,7 +34,7 @@
 | Response item persistence | ✅ GA | 2025-06-27 | Persists items via newline-wrapped comment markers (v2) that embed type, 16-character ULIDs and metadata. |
 | Open WebUI Notes compatibility | ✅ GA | 2025-07-14 | Works with ephemeral Notes that omit `chat_id`. |
 | Expandable status output | ✅ GA | 2025-07-01 | Progress steps rendered via `<details>` tags. Use `ExpandableStatusEmitter` to add entries. |
-| Inline citation events | ✅ GA | 2025-07-15 | Sources appear inline as `[n]` with clickable popups. |
+| Inline citation events | ✅ GA | 2025-07-16 | Sources appear inline as `[n]` by default. Use the `CITATION_STYLE` valve to show source names instead. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Deep Search Support | 🔄 In-progress | 2025-06-29 | Add support for o3-deep-research, o4-mini-deep-research. |
@@ -68,6 +68,11 @@
   * `auto` (default): removes middle context if the request exceeds token limits
   * `disabled`: returns a 400 error if the context is too long
     This works alongside per-model `max_completion_tokens` constraints.
+
+* **Citation style control**
+  Choose how inline citations appear using the `CITATION_STYLE` valve:
+  `number` (default) shows numeric markers like `[1]`, while `name` displays
+  the source title or filename instead.
 
 * **Custom parameter support**
   Pass OpenAI-compatible fields via Open WebUI's **Custom Parameters**.


### PR DESCRIPTION
## Summary
- simplify citation replacement in openai_responses manifold
- add `CITATION_STYLE` valve for inline citation appearance
- document new valve and update features table
- mention valve in citation docs
- bump pipe version to 0.8.20 and add changelog entry

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md functions/pipes/openai_responses_manifold/README.md docs/citations.md`

------
https://chatgpt.com/codex/tasks/task_e_6887c57352bc832e8bb49e0362f3b2a7