### PR TITLE
Add citation style valve and cleanup

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -173,6 +173,19 @@ Clicking a reference opens a detailed modal displaying the source snippet and me
 
 ---
 
+## 🎛 Controlling Citation Style
+
+The `openai_responses` pipe exposes a `CITATION_STYLE` valve to change how citation markers look:
+
+```text
+CITATION_STYLE = "number"       # [1] (default)
+CITATION_STYLE = "source_name"  # [example.com]
+```
+
+Only the visible marker changes—the citation event always contains the full source name and URL.
+
+---
+
 ## 💾 Persistence & Best Practices
 
 To ensure citations persist even if the user interrupts the response:

--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.8.19] - 2025-07-15
 - Added inline citation support with `[n]` markers and `citation` events.
 
+## [0.8.20] - 2025-07-28
+- Simplified citation handling and removed duplicate markdown links.
+- Added `CITATION_STYLE` valve to choose number or source name markers.
+
 ## [0.8.16] - 2025-06-28
 - Fixed custom separator handling in `ExpandableStatusEmitter`.
 - Corrected `Tuple` import for type hints.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -1,7 +1,7 @@
 # OpenAI Responses Manifold
 **Enables advanced OpenAI features (function calling, web search, visible reasoning summaries, and more) directly in [Open WebUI](https://github.com/open-webui/open-webui).**
 
-⚠️ **Version 0.8.18 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
+⚠️ **Version 0.8.20 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
 
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**
@@ -34,7 +34,7 @@
 | Response item persistence | ✅ GA | 2025-06-27 | Persists items via newline-wrapped comment markers (v2) that embed type, 16-character ULIDs and metadata. |
 | Open WebUI Notes compatibility | ✅ GA | 2025-07-14 | Works with ephemeral Notes that omit `chat_id`. |
 | Expandable status output | ✅ GA | 2025-07-01 | Progress steps rendered via `<details>` tags. Use `ExpandableStatusEmitter` to add entries. |
-| Inline citation events | ✅ GA | 2025-07-15 | Sources appear inline as `[n]` with clickable popups. |
+| Inline citation events | ✅ GA | 2025-07-28 | Valve `CITATION_STYLE` controls `[n]` vs source name. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
 | Deep Search Support | 🔄 In-progress | 2025-06-29 | Add support for o3-deep-research, o4-mini-deep-research. |


### PR DESCRIPTION
## Summary
- simplify citation logic in `openai_responses` manifold
- add `CITATION_STYLE` valve for number vs source name markers
- document new valve and update docs
- bump version to 0.8.20 and note in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md docs/citations.md`

------
https://chatgpt.com/codex/tasks/task_e_6887d41ffe74832e8bb7c7c1dd9b6a06