### PR TITLE
Only include reasoning param when explicitly provided

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 - Simplified citation handling and removed duplicate markdown links.
 - Added `CITATION_STYLE` valve to choose number or source name markers.
 
+## [0.8.21] - 2025-08-07
+- Only include `reasoning` parameter when explicitly provided.
+
 ## [0.8.16] - 2025-06-28
 - Fixed custom separator handling in `ExpandableStatusEmitter`.
 - Corrected `Tuple` import for type hints.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -1,7 +1,7 @@
 # OpenAI Responses Manifold
 **Enables advanced OpenAI features (function calling, web search, visible reasoning summaries, and more) directly in [Open WebUI](https://github.com/open-webui/open-webui).**
 
-⚠️ **Version 0.8.20 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
+⚠️ **Version 0.8.21 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
 
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**
@@ -24,8 +24,8 @@
 | Feature | Status | Last updated | Notes |
 | --- | --- | --- | --- |
 | Native function calling | ✅ GA | 2025-06-04 | Automatically enabled for supported models. |
-| Visible reasoning summaries | ✅ GA | 2025-06-03 | Available for o‑series models only. |
-| Encrypted reasoning tokens | ✅ GA | 2025-06-03 | Persists reasoning context across turns. |
+| Visible reasoning summaries | ✅ GA | 2025-08-07 | Available for o‑series models only. Requires `reasoning` parameter. |
+| Encrypted reasoning tokens | ✅ GA | 2025-08-07 | Persists reasoning context across turns. Requires `reasoning` parameter. |
 | Optimized token caching | ✅ GA | 2025-06-03 | Save up to ~50–75 % on supported models. |
 | Web search tool | ✅ GA | 2025-06-03 | Automatically invoked or toggled manually. |
 | Task model support | ✅ GA | 2025-06-06 | Use model as [Open WebUI External Task Model](https://docs.openwebui.com/tutorials/tips/improve-performance-local/) (title generation, tag generation, etc.). |

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -650,15 +650,23 @@ class Pipe:
                 )
                 return
             
-        # Enable reasoning summary, if supported and enabled
-        if model_family in FEATURE_SUPPORT["reasoning_summary"] and valves.ENABLE_REASONING_SUMMARY:
-            responses_body.reasoning = responses_body.reasoning or {}
+        # Enable reasoning summary only if the caller explicitly provided a
+        # ``reasoning`` parameter.
+        if (
+            model_family in FEATURE_SUPPORT["reasoning_summary"]
+            and valves.ENABLE_REASONING_SUMMARY
+            and responses_body.reasoning is not None
+        ):
             responses_body.reasoning["summary"] = valves.ENABLE_REASONING_SUMMARY
 
-        # Enable persistence of encrypted reasoning tokens, if supported and store=False
+        # Enable persistence of encrypted reasoning tokens only when
+        # ``reasoning`` was explicitly requested and store=False.
         # TODO make this configurable via valves since some orgs might not be approved for encrypted content
-        # Note storing encrypted contents is only supported when store = False
-        if model_family in FEATURE_SUPPORT["reasoning"] and responses_body.store is False:
+        if (
+            model_family in FEATURE_SUPPORT["reasoning"]
+            and responses_body.store is False
+            and responses_body.reasoning is not None
+        ):
             responses_body.include = responses_body.include or []
             responses_body.include.append("reasoning.encrypted_content")
 


### PR DESCRIPTION
## Summary
- Avoid auto-populating the `reasoning` field; require explicit request before adding summaries or encrypted tokens
- Document that reasoning summaries and encrypted tokens need the `reasoning` parameter

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_6894ff384210832e9cde076b8240757c