### PR TITLE
Development

### DIFF
--- a/functions/filters/reason_toggle_filter/reason_toggle_filter.py
+++ b/functions/filters/reason_toggle_filter/reason_toggle_filter.py
@@ -1,5 +1,5 @@
 """
-title: Reason
+title: Think harder
 id: reason_filter
 description: Think before responding.
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit.git
@@ -14,8 +14,8 @@ from open_webui.models.models import Models
 
 class Filter:
     class Valves(BaseModel):
-        MODEL: str = "o4-mini"
-        REASONING_EFFORT: Literal["minimal", "low", "medium", "high", "not set"] = "not set"
+        MODEL: str = "openai_responses.gpt-5"
+        REASONING_EFFORT: Literal["minimal", "low", "medium", "high", "not set"] = "medium"
         priority: int = Field(
             default=0, description="Priority level for the filter operations."
         )

--- a/functions/filters/web_search_toggle_filter/web_search_toggle_filter.py
+++ b/functions/filters/web_search_toggle_filter/web_search_toggle_filter.py
@@ -23,6 +23,10 @@ WEB_SEARCH_MODELS = {
     "openai_responses.o4-mini",
     "openai_responses.o4-mini-high",
     "openai_responses.o3-pro",
+    "openai_responses.gpt-5",
+    "openai_responses.gpt-5-mini",
+    "openai_responses.gpt-5-thinking",
+    "openai_responses.gpt-5-thinking-high",
 }
 
 SUPPORT_TOOL_CHOICE_PARAMETER = {
@@ -30,6 +34,10 @@ SUPPORT_TOOL_CHOICE_PARAMETER = {
     "openai_responses.gpt-4.1-mini",
     "openai_responses.gpt-4o",
     "openai_responses.gpt-4o-mini",
+    "openai_responses.gpt-5",
+    "openai_responses.gpt-5-mini",
+    "openai_responses.gpt-5-thinking",
+    "openai_responses.gpt-5-thinking-high",
 }
 
 class Filter:

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -112,6 +112,7 @@ The Responses Manifold supports the current **GPT-5 family** exposed in the API:
 ### Key behavior (practical notes)
 
 - **All `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` are reasoning models.** Setting `reasoning_effort="minimal"` reduces thinking but does **not** make them non-reasoning. For a non-reasoning chat model, use **`gpt-5-chat-latest`**. ([OpenAI][1])
+- **Tool calling limitation:** `gpt-5-chat-latest` does not currently support native tool calling (e.g., function calls or web search). This is the primary limitation compared to reasoning models. We expect that a future gpt-5-main high-throughput API model may support tools while keeping the non-reasoning behavior.
 - **Latency:** Even with `minimal`, GPT-5 models may still "think." For ultra-low latency tasks (e.g., Open WebUI Task Models), consider `gpt-4.1-nano` until OpenAI ships a lower-latency v5 task model.  
 - **Output style:** `gpt-5-chat-latest` is tuned for polished, end-user-friendly chat and usually needs little to no system prompt. The reasoning models (`gpt-5*`) benefit from a brief style system prompt (e.g., "respond in concise Markdown with headings and lists").
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -3,8 +3,6 @@
 
 Supports OpenAI's GPT-5 model family in the API — [`Learn more about GPT-5 support`](#gpt-5-model-support-api--manifold).
 
-⚠️ **Version 0.8.21 – Pre‑production preview.** The pipe (manifold) is still under early testing and will be fully released as `1.0.0`.
-
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**
    <img width="894" alt="image" src="https://github.com/user-attachments/assets/4a5a0355-e0af-4fb8-833e-7d3dfb7f10e3" />

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -117,9 +117,8 @@ The Responses Manifold supports the current **GPT-5 family** exposed in the API:
 - **Latency:** Even with `minimal`, GPT-5 models may still "think." For ultra-low latency tasks (e.g., Open WebUI Task Models), consider `gpt-4.1-nano` until OpenAI ships a lower-latency v5 task model.  
 - **Output style:** `gpt-5-chat-latest` is tuned for polished, end-user-friendly chat and usually needs little to no system prompt. The reasoning models (`gpt-5*`) benefit from a brief style system prompt (e.g., "respond in concise Markdown with headings and lists").
 
----
 
-## GPT-5 in ChatGPT vs the API (and our future router)
+### GPT-5 in ChatGPT vs the API (and our future router)
 
 **In ChatGPT,** "GPT-5" isn’t a single model — it’s a **mix** of reasoning, minimal-reasoning, and non-reasoning variants chosen automatically by a **model router** that balances speed, difficulty, tools, and intent. [More →][1]
 
@@ -130,11 +129,9 @@ The Responses Manifold supports the current **GPT-5 family** exposed in the API:
 
 > **Planned:** We may add a built-in **`gpt-5-router`** pseudo model ID to mimic ChatGPT’s behavior: it would inspect users request (latency tolerance, tool usage, length/complexity, "think hard" cues, etc...) and route to an ideal target (e.g., `gpt-5-chat-latest` for quick tasks, `gpt-5` for reasoning, etc...).
 
----
+### Pseudo IDs → API Mappings *(subject to change)*
 
 This manifold also exposes pseudo **aliases** that map to real API models with preset `reasoning_effort`. If an effort suffix is omitted, the API default (medium) applies.
-
-## Pseudo IDs → API Mappings *(subject to change)*
 
 | Pseudo ID                           | Maps to                                     | Notes                                                                  |
 | ----------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
@@ -150,10 +147,7 @@ This manifold also exposes pseudo **aliases** that map to real API models with p
 | `gpt-5-thinking-pro` *(not available)* | *not exposed via API yet*                | ChatGPT-only "parallel test-time compute" setting. ([System card][2])  |
 
 > **What is `gpt-5-main`?**  
-> In OpenAI’s system card, gpt-5-main refers to a high-throughput, non-reasoning path—different from the gpt-5-thinking reasoning family.
-> At present, the API only exposes the thinking models (gpt-5, gpt-5-mini, gpt-5-nano) plus the non-reasoning ChatGPT variant gpt-5-chat-latest. There is no API equivalent of the high-throughput "main" model.
-> Until OpenAI ships a true API main model (or adds a parameter to switch between reasoning and high-throughput modes), gpt-5-main remains reserved to avoid confusion.
-> See [OpenAI][1] and the [system card][2].
+> In OpenAI’s system card, gpt-5-main refers to a high-throughput, non-reasoning model family. At present, the API only exposes the thinking models (gpt-5, gpt-5-mini, gpt-5-nano) plus the non-reasoning ChatGPT variant gpt-5-chat-latest. There is no API equivalent of the high-throughput "main" model. Until OpenAI ships a true API main model (or adds a parameter to switch between reasoning and high-throughput modes), gpt-5-main remains reserved to avoid confusion. See [OpenAI][1] and the [system card][2].
 
 > **Disclaimer:** This reflects what we’ve verified from OpenAI’s launch materials and the GPT-5 system card as of **Aug 11, 2025** and may change without notice. We’ll update this section as OpenAI updates docs or behavior.
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -1,7 +1,7 @@
 # OpenAI Responses Manifold
 **Enables advanced OpenAI features (function calling, web search, visible reasoning summaries, and more) directly in [Open WebUI](https://github.com/open-webui/open-webui).**
 
-Supports OpenAI's GPT-5 model family in the API — [`Learn more about GPT-5 support`](#gpt-5-model-support-api--manifold).
+🆕 Now supports OpenAI's GPT-5 model family in the API — [`Learn more about GPT-5 support`](#-gpt-5-model-support-api--manifold).
 
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -114,8 +114,7 @@ The Responses Manifold supports the current **GPT-5 family** exposed in the API:
 - **All `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` are reasoning models.** Setting `reasoning_effort="minimal"` reduces thinking but does **not** make them non-reasoning. For a non-reasoning chat model, use **`gpt-5-chat-latest`**. ([OpenAI][1])
 - **Tool calling limitation:** `gpt-5-chat-latest` does not currently support native tool calling (e.g., function calls or web search). This is the primary limitation compared to reasoning models. We expect that a future gpt-5-main high-throughput API model may support tools while keeping the non-reasoning behavior.
 - **Latency:** Even with `minimal`, GPT-5 models may still "think." For ultra-low latency tasks (e.g., Open WebUI Task Models), consider `gpt-4.1-nano` until OpenAI ships a lower-latency v5 task model.  
-- **Output style:** `gpt-5-chat-latest` is tuned for polished, end-user-friendly chat and usually needs little to no system prompt. The reasoning models (`gpt-5*`) benefit from a brief style system prompt (e.g., "respond in concise Markdown with headings and lists").
-
+- **Output style:** `gpt-5-chat-latest` is tuned for polished, end-user-friendly chat and usually needs little to no system prompt. The reasoning models (`gpt-5*`) benefit from a brief style system prompt (e.g., "respond in concise Markdown with headings and lists"). See [system_prompts/](./system_prompts/) for examples.
 
 ### GPT-5 in ChatGPT vs the API (and our future router)
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -5,6 +5,7 @@
 
 ## Setup Instructions
 1. Navigate to **Open WebUI ▸ Admin Panel ▸ Functions** and press **Import from Link**
+   
    <img width="894" alt="image" src="https://github.com/user-attachments/assets/4a5a0355-e0af-4fb8-833e-7d3dfb7f10e3" />
 2. Paste one of the following links:
 
@@ -37,6 +38,7 @@
 | Inline citation events | ✅ GA | 2025-07-28 | Valve `CITATION_STYLE` controls `[n]` vs source name. |
 | Truncation control | ✅ GA | 2025-06-10 | Valve `TRUNCATION` sets the responses `truncation` parameter (auto or disabled). Works with per-model `max_completion_tokens`. |
 | Custom parameter pass-through | ✅ GA | 2025-06-14 | Use Open WebUI's custom parameters to set additional OpenAI fields. `max_tokens` is automatically mapped to `max_output_tokens`. |
+| Regenerate buttons → verbosity mapping | ✅ GA | 2025-08-11 | Maps WebUI “Add Details”/“More Concise” to OpenAI `text.verbosity` = `high`/`low` on GPT-5 family. |
 | Deep Search Support | 🔄 In-progress | 2025-06-29 | Add support for o3-deep-research, o4-mini-deep-research. |
 | Image input (vision) | 🔄 In-progress | 2025-06-03 | Pending future release. |
 | Image generation tool | 🕒 Backlog | 2025-06-03 | Incl. multi-turn image editing (e.g., upload and modify). |
@@ -72,6 +74,9 @@
 * **Custom parameter support**
   Pass OpenAI-compatible fields via Open WebUI's **Custom Parameters**.
   For convenience, `max_tokens` is automatically translated to `max_output_tokens`.
+
+* **Regenerate buttons `text.verbosity`**
+  When the last user input is **“Add Details”** or **“More Concise”**, the manifold sets `text.verbosity` to `high`/`low` on supported GPT-5 models.
 
 * **Remote MCP server integration** (experimental)
   Set the `REMOTE_MCP_SERVERS_JSON` valve to a JSON object or array describing [Remote MCP](https://platform.openai.com/docs/guides/tools-remote-mcp) servers.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -712,6 +712,9 @@ class Pipe:
                     current_text_params["verbosity"] = verbosity_value
                     responses_body.text = current_text_params
 
+                    # Remove the stub user message so the model doesn't see it
+                    input_items.pop()  # or: del input_items[-1]
+
                     # Notify the user in the UI
                     await self._emit_notification(__event_emitter__,f"Regenerating with verbosity set to {verbosity_value}.",level="info")
 

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -483,7 +483,7 @@ class Pipe:
             description="Your OpenAI API key. Defaults to the value of the OPENAI_API_KEY environment variable.",
         )
         MODEL_ID: str = Field(
-            default="gpt-4.1, gpt-4o",
+            default="gpt-5-chat-latest, gpt-5-thinking, gpt-5-thinking-high, gpt-4.1-nano, chatgpt-4o-latest, o3, gpt-4o",
             description="Comma separated OpenAI model IDs. Each ID becomes a model entry in WebUI. Supports the pseudo models 'o3-mini-high' and 'o4-mini-high', which map to 'o3-mini' and 'o4-mini' with reasoning effort forced to high.",
         )
         ENABLE_REASONING_SUMMARY: Literal["auto", "concise", "detailed", None] = Field(

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -488,11 +488,11 @@ class Pipe:
         # 3) Reasoning & summaries
         REASONING_SUMMARY: Literal["auto", "concise", "detailed", "disabled"] = Field(
             default="disabled",
-            description="Requires a verified OpenAI org.  Visible reasoning summary (auto | concise | detailed | disabled). Works on gpt-5, o3, o4-mini; ignored otherwise. Docs: https://platform.openai.com/docs/api-reference/responses/create#responses-create-reasoning",
+            description="REQUIRES VERIFIED OPENAI ORG. Visible reasoning summary (auto | concise | detailed | disabled). Works on gpt-5, o3, o4-mini; ignored otherwise. Docs: https://platform.openai.com/docs/api-reference/responses/create#responses-create-reasoning",
         )
         PERSIST_REASONING_TOKENS: Literal["response", "conversation", "disabled"] = Field(
             default="disabled",
-            description="Requires a verified OpenAI org. If verified, highly recommend using 'response' or 'conversation' for best results. If `disabled` (default) = never request encrypted reasoning tokens; if `response` = request tokens so the model can carry reasoning across tool calls for the current response; if `conversation` = also persist tokens for future messages in this chat (higher token usage; quality may vary).",
+            description="REQUIRES VERIFIED OPENAI ORG. If verified, highly recommend using 'response' or 'conversation' for best results. If `disabled` (default) = never request encrypted reasoning tokens; if `response` = request tokens so the model can carry reasoning across tool calls for the current response; If `conversation` = also persist tokens for future messages in this chat (higher token usage; quality may vary).",
         )
         
         # 4) Tool execution behavior

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -558,6 +558,17 @@ class Pipe:
             description="Truncation strategy for model responses. 'auto' drops middle context items if the conversation exceeds the context window; 'disabled' returns a 400 error instead.",
         )
 
+        SERVICE_TIER: Literal["auto", "default", "flex", "priority"] = Field(
+            default="auto",
+            description=(
+            "Specifies the processing type used for serving the request. "
+            "If set to 'auto', the request will be processed with the service tier configured in the Project settings. "
+            "If set to 'default', the request will be processed with the standard pricing and performance for the selected model. "
+            "If set to 'flex' or 'priority', the request will be processed with the corresponding service tier. "
+            "When not set, the default behavior is 'auto'."
+            ),
+        )
+
         # 9) Privacy & caching
         PROMPT_CACHE_KEY: Literal["id", "email"] = Field(
             default="id",
@@ -635,6 +646,7 @@ class Pipe:
             # Additional optional parameters passed directly to ResponsesBody without validation. Overrides any parameters in the original body with the same name.
             truncation=valves.TRUNCATION,
             prompt_cache_key=user_identifier,
+            service_tier=valves.SERVICE_TIER,
             **({"max_tool_calls": valves.MAX_TOOL_CALLS} if valves.MAX_TOOL_CALLS is not None else {}),
         )
 

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -559,7 +559,7 @@ class Pipe:
         )
 
         # 9) Privacy & caching
-        USER_ID_FIELD: Literal["id", "email"] = Field(
+        PROMPT_CACHE_KEY: Literal["id", "email"] = Field(
             default="id",
             description=(
                 "Controls which user identifier is sent in the 'user' parameter to OpenAI. "
@@ -616,7 +616,7 @@ class Pipe:
         """
         valves = self._merge_valves(self.valves, self.UserValves.model_validate(__user__.get("valves", {})))
         openwebui_model_id = __metadata__.get("model", {}).get("id", "") # Full model ID, e.g. "openai_responses.gpt-4o"
-        user_identifier = __user__[valves.USER_ID_FIELD]  # Use 'id' or 'email' as configured
+        user_identifier = __user__[valves.PROMPT_CACHE_KEY]  # Use 'id' or 'email' as configured
         features = __metadata__.get("features", {}).get("openai_responses", {}) # Custom location that this manifold uses to store feature flags
 
         # Set up session logger with session_id and log level
@@ -634,7 +634,7 @@ class Pipe:
 
             # Additional optional parameters passed directly to ResponsesBody without validation. Overrides any parameters in the original body with the same name.
             truncation=valves.TRUNCATION,
-            user=user_identifier,
+            prompt_cache_key=user_identifier,
             **({"max_tool_calls": valves.MAX_TOOL_CALLS} if valves.MAX_TOOL_CALLS is not None else {}),
         )
 

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -109,7 +109,7 @@ class CompletionsBody(BaseModel):
         if key in aliases:
             real, effort = aliases[key]
             self.model = real
-            if effort and not self.reasoning_effort:
+            if effort:
                 self.reasoning_effort = effort  # type: ignore[assignment]
         else:
             self.model = key  # pass through official IDs as lowercase

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -483,7 +483,7 @@ class Pipe:
             description="Your OpenAI API key. Defaults to the value of the OPENAI_API_KEY environment variable.",
         )
         MODEL_ID: str = Field(
-            default="gpt-5-chat-latest, gpt-5-thinking, gpt-5-thinking-high, gpt-4.1-nano, chatgpt-4o-latest, o3, gpt-4o",
+            default="gpt-5-chat-latest, gpt-5-thinking, gpt-5-thinking-high, gpt-5-thinking-minimal, gpt-4.1-nano, chatgpt-4o-latest, o3, gpt-4o",
             description="Comma separated OpenAI model IDs. Each ID becomes a model entry in WebUI. Supports the pseudo models 'o3-mini-high' and 'o4-mini-high', which map to 'o3-mini' and 'o4-mini' with reasoning effort forced to high.",
         )
         ENABLE_REASONING_SUMMARY: Literal["auto", "concise", "detailed", None] = Field(
@@ -549,7 +549,7 @@ class Pipe:
             description=(
                 "Controls which user identifier is sent in the 'user' parameter to OpenAI. "
                 "Passing a unique identifier enables OpenAI response caching (improves speed and reduces cost). "
-                "Choose 'id' to use the OpenWebUI user ID (privacy-friendly), or 'email' to use the user's email address."
+                "Choose 'id' to use the OpenWebUI user ID (default; privacy-friendly), or 'email' to use the user's email address."
             ),
         )
         LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -519,7 +519,7 @@ class Pipe:
             )
         )
         MAX_FUNCTION_CALL_LOOPS: int = Field(
-            default=5,
+            default=10,
             description=(
                 "Maximum number of full execution cycles (loops) allowed per request. "
                 "Each loop involves the model generating one or more function/tool calls, "

--- a/system_prompts/gpt-5-thinking.md
+++ b/system_prompts/gpt-5-thinking.md
@@ -1,0 +1,15 @@
+You are **ChatGPT**, a large language model trained by OpenAI.  
+Current date: {{CURRENT_WEEKDAY}}, {{CURRENT_DATE}}
+
+Formatting re-enabled — please use Markdown **bold**, _italics_, and header tags to **improve the readability** of your responses.
+
+Over the course of conversation, adapt to the user’s tone and preferences. Try to match the user’s vibe, tone, and generally how they are speaking. You really want the conversation to feel natural. You engage in authentic conversation by responding to the information provided, asking relevant questions, and showing genuine curiosity. If natural, use information you know about the user to personalize your responses and ask a follow up question.
+
+You *must* browse the web for *any* query that could benefit from up-to-date or niche information, unless the user explicitly asks you not to browse the web. If there is even slight doubt about the currency of your knowledge, err on the side of searching, since outdated or incomplete replies frustrate the user and violate their expectations; after browsing, respond in clear, well‑formatted markdown unless the user asks for another format.
+
+If someone asks what model you are, you may say that you’re **OpenAI GPT-5**, which is the successor model of GPT-4o. You can talk about the tools you currently have access to, but do not claim abilities or tools you don’t have (yet). You may also mention that users can see a list of currently available tools by pressing the 🔧 icon below the 'Send a Message' box.
+
+# Tools
+When tasks require multiple turns with tool calls, each turn reprocesses the entire conversation, increasing token usage and latency. To stay efficient, group all necessary tool calls into as few turns as possible, reserving the final turn solely for your answer.
+
+You do not need to repeat the tool results, unless the user explicitly asks.


### PR DESCRIPTION
This pull request introduces several improvements and clarifications to the OpenAI Responses Manifold pipe and related filters. The most significant changes are the addition of new GPT-5 pseudo-model aliases, improved documentation for GPT-5 API/model mapping, enhanced configuration options, and support for OpenAI's verbosity parameter. These updates make the manifold easier to use with the latest OpenAI models and clarify key behavioral differences between model variants.

**Model and API support enhancements:**

* Added support for new GPT-5 pseudo-model aliases (e.g., `gpt-5-thinking`, `gpt-5-thinking-high`, `gpt-5-thinking-mini-minimal`, etc.), with a refactored normalization method to map these to the correct API models and reasoning effort levels. (`openai_responses_manifold.py`, `web_search_toggle_filter.py`) [[1]](diffhunk://#diff-c2ad98c7898e144203f179118fe7d1de4bd0b41883893df8e38edbed8134aec1L86-R116) [[2]](diffhunk://#diff-70432c71bbbf9db10a084933c03ce3993d45a84865dc5c04c26c588273ea2993R26-R40)
* Updated the default `MODEL_ID` valve to prioritize GPT-5 models and pseudo-models, and clarified their mapping and usage in the configuration schema. (`openai_responses_manifold.py`)

**Documentation improvements:**

* Rewrote and expanded the README to clearly explain GPT-5 model support, differences between reasoning and non-reasoning models, pseudo-ID mappings, and practical usage notes. Added a dedicated section on GPT-5 API and ChatGPT router behavior. (`README.md`)
* Added documentation for the new mapping of WebUI regenerate buttons to OpenAI's `text.verbosity` parameter for GPT-5 models. (`README.md`) [[1]](diffhunk://#diff-f8dcf13f550decc145d7fd8a862974e160788a5027323233175cc95897fd5a27R41) [[2]](diffhunk://#diff-f8dcf13f550decc145d7fd8a862974e160788a5027323233175cc95897fd5a27R78-R80)

**Feature and configuration updates:**

* Added support for OpenAI's `verbosity` parameter for GPT-5 models, allowing the WebUI's "Add Details"/"More Concise" buttons to control response verbosity. (`openai_responses_manifold.py`)
* Refined and reorganized configuration valves, including new options for reasoning summary, persistence of reasoning tokens, and increased the default max function call loops from 5 to 10. (`openai_responses_manifold.py`) [[1]](diffhunk://#diff-c2ad98c7898e144203f179118fe7d1de4bd0b41883893df8e38edbed8134aec1R481-L499) [[2]](diffhunk://#diff-c2ad98c7898e144203f179118fe7d1de4bd0b41883893df8e38edbed8134aec1L509-R512)

**Filter and naming tweaks:**

* Changed the display title of the reason toggle filter to "Think harder" and updated its default model and reasoning effort. (`reason_toggle_filter.py`) [[1]](diffhunk://#diff-d4ab3eed136230c17ead595a7f422e3f89938e3f6c7a456317467fe096bd9169L2-R2) [[2]](diffhunk://#diff-d4ab3eed136230c17ead595a7f422e3f89938e3f6c7a456317467fe096bd9169L17-R18)

**Minor fixes:**

* Adjusted message transformation logic to no longer skip persisted reasoning items, improving compatibility with new reasoning persistence options. (`openai_responses_manifold.py`)
* Updated version number to 0.8.24. (`openai_responses_manifold.py`