### PR TITLE
feat: add gpt-5-auto placeholder model

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.25] - 2025-08-13
+- Added placeholder `gpt-5-auto` model that currently routes to `gpt-5-chat-latest`
+  and emits a "model router coming soon" notification.
+- Fixed `transform_messages_to_input` to skip missing persisted items.
+- Used `openwebui_model_id` to detect `gpt-5-auto` and added a stub router helper
+  for future model selection.
+- Clarified `MODEL_ID` description to mention supported pseudo models.
+
 ## [0.8.17] - 2025-07-01
 - Added `ExpandableStatusIndicator` updates in the non-streaming loop.
 

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -52,7 +52,7 @@
 ### Other Features
 
 * **Pseudo-model aliases**
-  You can list `o3-mini-high`, `o4-mini-high`, `gpt-5-high`, `gpt-5-thinking`, `gpt-5-minimal`, `gpt-5-mini-minimal`, and `gpt-5-nano-minimal` in the `MODELS` valve just like regular models.
+  You can list `gpt-5-auto`, `o3-mini-high`, `o4-mini-high`, `gpt-5-high`, `gpt-5-thinking`, `gpt-5-minimal`, `gpt-5-mini-minimal`, and `gpt-5-nano-minimal` in the `MODELS` valve just like regular models.
   These are **virtual aliases** (not real OpenAI models) that automatically map to the underlying model and set `reasoning_effort` to `"high"` or `"minimal"` as indicated.
   For example, `gpt-5-thinking` uses `gpt-5` with `reasoning_effort="high"`, while the `*-minimal` variants run with minimal reasoning and are handy for task models like a hidden `gpt-5-mini-minimal`.
 
@@ -126,11 +126,11 @@ The Responses Manifold supports the current **GPT-5 family** exposed in the API:
 **In ChatGPT,** "GPT-5" isn’t a single model — it’s a **mix** of reasoning, minimal-reasoning, and non-reasoning variants chosen automatically by a **model router** that balances speed, difficulty, tools, and intent. [More →][1]
 
 **In the API,** you pick specific models directly:
-- `gpt-5`, `gpt-5-mini`, `gpt-5-nano` — reasoning enabled by default.  
-- `reasoning_effort="minimal"` reduces thinking but is **not** the same as the non-reasoning ChatGPT model.  
+- `gpt-5`, `gpt-5-mini`, `gpt-5-nano` — reasoning enabled by default.
+- `reasoning_effort="minimal"` reduces thinking but is **not** the same as the non-reasoning ChatGPT model.
 - The **non-reasoning** ChatGPT variant is exposed separately as **`gpt-5-chat-latest`**.
 
-> **Planned:** We may add a built-in **`gpt-5-router`** pseudo model ID to mimic ChatGPT’s behavior: it would inspect users request (latency tolerance, tool usage, length/complexity, "think hard" cues, etc...) and route to an ideal target (e.g., `gpt-5-chat-latest` for quick tasks, `gpt-5` for reasoning, etc...).
+> **Placeholder:** The **`gpt-5-auto`** pseudo model currently routes to `gpt-5-chat-latest` and shows a "model router coming soon" notification. A smarter router that selects between GPT‑5 variants is planned for a future release.
 
 ### Pseudo IDs → API Mappings *(subject to change)*
 
@@ -138,6 +138,7 @@ This manifold also exposes pseudo **aliases** that map to real API models with p
 
 | Pseudo ID                           | Maps to                                     | Notes                                                                  |
 | ----------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| `gpt-5-auto`                        | `gpt-5-chat-latest`                         | Placeholder router; displays notification and routes to chat model.     |
 | `gpt-5-thinking`                    | `gpt-5`                                     | Default (medium) reasoning; mirrors "thinking".                        |
 | `gpt-5-thinking-minimal`            | `gpt-5` + `reasoning_effort="minimal"`      | Fastest `gpt-5` while still a reasoning model. ([OpenAI][1])           |
 | `gpt-5-thinking-high`               | `gpt-5` + `reasoning_effort="high"`         | Maximum test-time reasoning. ([OpenAI][1])                              |


### PR DESCRIPTION
## Summary
- add `gpt-5-auto` placeholder that notifies users and routes to `gpt-5-chat-latest`
- expose new model in default valve, documentation, and pseudo-model list
- skip missing persisted items when rebuilding message history
- detect `gpt-5-auto` via `openwebui_model_id` and introduce stub router helper for future model selection

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/README.md functions/pipes/openai_responses_manifold/CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_689cb0985ecc832e9a21744feb081999