### PR TITLE
fix: await tools for Open WebUI v0.6.23

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.28] - 2025-08-21
+- Resolved compatibility with Open WebUI v0.6.23 by awaiting `__tools__` when
+  it is provided as a coroutine.
+
 ## [0.8.26] - 2025-08-13
 - Escaped tool results to prevent Markdown code block escalation.
 - Fixed regex replacement in status rendering to handle backslashes safely.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -6,7 +6,7 @@ author_url: https://github.com/jrkropp
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.27
+version: 0.8.28
 license: MIT
 """
 
@@ -686,13 +686,17 @@ class Pipe:
 
         # Normalize to family-level model name (e.g., 'o3' from 'o3-2025-04-16') to be used for feature detection.
         model_family = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", responses_body.model)
-        
+
+        # Resolve __tools__ coroutine returned by newer Open WebUI versions.
+        if inspect.isawaitable(__tools__):
+            __tools__ = await __tools__
+
         # Add Open WebUI Tools (if any) to the ResponsesBody.
         # TODO: Also detect body['tools'] and merge them with __tools__.  This would allow users to pass tools in the request body from filters, etc.
         if __tools__ and model_family in FEATURE_SUPPORT["function_calling"]:
             responses_body.tools = ResponsesBody.transform_tools(
-                tools = __tools__,
-                strict = True
+                tools=__tools__,
+                strict=True,
             )
 
         # Add web_search tool only if supported, enabled, and effort != minimal


### PR DESCRIPTION
## Summary
- await `__tools__` before use to handle asynchronous tool resolution introduced in Open WebUI v0.6.23
- update OpenAI Responses Manifold version to 0.8.28
- document fix in changelog

## Testing
- `pre-commit run --files functions/pipes/openai_responses_manifold/openai_responses_manifold.py functions/pipes/openai_responses_manifold/CHANGELOG.md`

------
https://chatgpt.com/codex/tasks/task_e_68a77a7d6138832e94ec2df6729c0201