### PR TITLE
feat: add GPT-5 auto router

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ## [0.9.1] - 2025-08-28
 - Added `ENABLE_STRICT_TOOL_CALLING` valve (default: `True`). When enabled, the manifold converts Open WebUI registry tools to strict JSON Schemas and sets `strict: true` on function tools when passing to the OpenAI Responses API.
 
+## [0.9.2] - 2025-09-25
+- Introduced GPT-5 auto router: uses `gpt-4.1-nano` to analyze the prompt and update the request with the best GPT-5 variant.
+
 
 ## [0.9.0] - 2025-08-28
 - Added `extra_tools` field for filter-injected tools with a single merge point and deduplication.

--- a/functions/pipes/openai_responses_manifold/README.md
+++ b/functions/pipes/openai_responses_manifold/README.md
@@ -151,7 +151,7 @@ These **aliases** are supported by the pipe (via the `MODELS` valve). They resol
 
 | **Alias (you can use these in OpenAI Responses Manifold)**                        | **Resolves to (official ID)** | **Preset(s)**                | Suggested use                                                         |
 | ------------------------------------------------------------------ | ----------------------------- | ---------------------------- | --------------------------------------------------------------------- |
-| `gpt-5-auto`                                                       | `gpt-5-chat-latest`           | Router placeholder           | Router placeholder.  Automatic selection planned.                     |
+| `gpt-5-auto`                                                       | Dynamic GPT-5 variant         | —                            | Automatically routes between GPT-5 models (chat, mini, nano) using a fast classifier.                     |
 | `gpt-5-thinking`                                                   | `gpt-5`                       | Default (medium) reasoning   | General high‑quality prompts. ([OpenAI][8])                           |
 | `gpt-5-thinking-minimal`                                           | `gpt-5`                       | `reasoning_effort="minimal"` | Faster/cheaper while still reasoning. ([OpenAI][8])                   |
 | `gpt-5-thinking-high`                                              | `gpt-5`                       | `reasoning_effort="high"`    | Hard problems; max quality. ([OpenAI][8])                             |
@@ -203,7 +203,7 @@ The Responses Manifold supports the current **GPT‑5 family** exposed in the AP
 * `reasoning_effort="minimal"` lowers compute but isn’t the same as non‑reasoning ChatGPT.
 * The **non‑reasoning** variant is **`gpt-5-chat-latest`**.
 
-> **Note:** The **`gpt-5-auto`** pseudo model currently routes to `gpt-5-chat-latest` and shows a “model router coming soon” notification. A smarter router that selects between GPT‑5 variants is planned.
+> **Note:** The **`gpt-5-auto`** pseudo model uses a lightweight `gpt-4.1-nano` request to classify the prompt and automatically choose the appropriate GPT‑5 variant.
 
 [1]: https://openai.com/index/introducing-gpt-5-for-developers/ "Introducing GPT‑5 for developers | OpenAI"
 [2]: https://cdn.openai.com/pdf/8124a3ce-ab78-4f06-96eb-49ea29ffb52f/gpt5-system-card-aug7.pdf "GPT‑5 System Card (Aug 7, 2025)"

--- a/functions/pipes/openai_responses_manifold/tests/test_route_gpt5_auto.py
+++ b/functions/pipes/openai_responses_manifold/tests/test_route_gpt5_auto.py
@@ -1,0 +1,49 @@
+import json
+import sys
+import types
+import pytest
+
+# Stub minimal open_webui modules required for import
+owui_root = types.ModuleType("open_webui")
+models_pkg = types.ModuleType("open_webui.models")
+sys.modules.setdefault("open_webui", owui_root)
+sys.modules.setdefault("open_webui.models", models_pkg)
+sys.modules.setdefault("open_webui.models.chats", types.SimpleNamespace(Chats=object))
+sys.modules.setdefault(
+    "open_webui.models.models",
+    types.SimpleNamespace(ModelForm=object, Models=object),
+)
+
+from functions.pipes.openai_responses_manifold.openai_responses_manifold import Pipe, ResponsesBody
+
+
+@pytest.mark.asyncio
+async def test_route_gpt5_auto_updates_body(monkeypatch):
+    pipe = Pipe()
+    body = ResponsesBody(model="gpt-5-chat-latest", input=[{"role": "user", "content": "hi"}])
+    valves = pipe.Valves()
+
+    async def fake_request(params, api_key, base_url):
+        assert params["model"] == "gpt-4.1-nano"
+        assert params["input"] == "hi"
+        assert "instructions" in params
+        router_result = {"model": "gpt-5-nano"}
+        return {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": json.dumps(router_result)}
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        pipe,
+        "send_openai_responses_nonstreaming_request",
+        fake_request,
+    )
+
+    updated = await pipe._route_gpt5_auto(body, valves)
+    assert updated.model == "gpt-5-nano"

--- a/functions/pipes/openai_responses_manifold/tests/test_transform_owui_tools.py
+++ b/functions/pipes/openai_responses_manifold/tests/test_transform_owui_tools.py
@@ -1,5 +1,18 @@
 import json
+import sys
 import textwrap
+import types
+
+# Stub minimal open_webui modules required for import
+owui_root = types.ModuleType("open_webui")
+models_pkg = types.ModuleType("open_webui.models")
+sys.modules.setdefault("open_webui", owui_root)
+sys.modules.setdefault("open_webui.models", models_pkg)
+sys.modules.setdefault("open_webui.models.chats", types.SimpleNamespace(Chats=object))
+sys.modules.setdefault(
+    "open_webui.models.models",
+    types.SimpleNamespace(ModelForm=object, Models=object),
+)
 
 from functions.pipes.openai_responses_manifold.openai_responses_manifold import ResponsesBody
 


### PR DESCRIPTION
## Summary
- add gpt-4.1-nano powered router for `gpt-5-auto`
- update docs to describe automatic GPT-5 model selection
- add tests for routing helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c60b2738832ebf436da3bba90f99