### PR TITLE
docs: add status emitter example

### DIFF
--- a/functions/pipes/status_emitter_example/README.md
+++ b/functions/pipes/status_emitter_example/README.md
@@ -1,0 +1,18 @@
+# Status Emitter Example
+
+Demonstrates how a pipe can emit every supported `status` action to Open WebUI.
+Each update waits **two seconds** before sending the next so you can observe the
+UI transitions.
+
+The accompanying [`status_emitter_example.py`](status_emitter_example.py) script
+sends:
+
+- a plain status message
+- expandable `web_search` results using both `items` and `urls`
+- a `knowledge_search` lookup
+- `web_search_queries_generated` and `queries_generated` suggestions
+- a `sources_retrieved` count
+- hidden and error statuses
+
+Run this pipe in your Open WebUI instance to see how the frontend renders each
+entry in the status history.

--- a/functions/pipes/status_emitter_example/status_emitter_example.py
+++ b/functions/pipes/status_emitter_example/status_emitter_example.py
@@ -1,0 +1,83 @@
+"""Status Emitter Demo.
+
+title: Status Emitter Demo
+id: status_emitter_example
+author: OpenAI Codex
+description: Demonstrates emitting diverse status actions with delays.
+version: 1.0.0
+license: MIT
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncGenerator, Awaitable, Callable
+
+
+class Pipe:
+    """Simple pipe that emits a variety of status events."""
+
+    async def pipe(
+        self,
+        _body: dict[str, Any],
+        __event_emitter__: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        __metadata__: dict[str, Any] | None = None,
+        *_,
+    ) -> AsyncGenerator[str, None]:
+        """Emit example status events, pausing two seconds between each."""
+
+        if not __event_emitter__:
+            yield "No event emitter provided."
+            return
+
+        statuses = [
+            {"description": "Starting demo", "done": False},
+            {
+                "action": "web_search",
+                "description": "Searched {{count}} sites",
+                "query": "open webui",
+                "items": [
+                    {"title": "Open WebUI", "link": "https://github.com/open-webui/open-webui"},
+                    {"title": "Open WebUI Docs", "link": "https://docs.openwebui.com"},
+                ],
+                "done": True,
+            },
+            {
+                "action": "web_search",
+                "description": "Searched {{count}} sites",
+                "query": "open webui",
+                "urls": [
+                    "https://github.com/open-webui/open-webui",
+                    "https://docs.openwebui.com",
+                ],
+                "done": True,
+            },
+            {
+                "action": "knowledge_search",
+                "query": "vector database",
+                "done": False,
+            },
+            {
+                "action": "web_search_queries_generated",
+                "queries": ["Open WebUI", "status events"],
+                "done": False,
+            },
+            {
+                "action": "queries_generated",
+                "queries": ["vector search", "semantic ranking"],
+                "done": False,
+            },
+            {
+                "action": "sources_retrieved",
+                "count": 2,
+                "done": True,
+            },
+            {"description": "Hidden completion", "done": True, "hidden": True},
+            {"description": "Search failed", "done": True, "error": True},
+        ]
+
+        for data in statuses:
+            await __event_emitter__({"type": "status", "data": data})
+            await asyncio.sleep(2)
+
+        yield "Status emitter demo complete."


### PR DESCRIPTION
## Summary
- reference runnable status emitter demo in docs
- add status_emitter_example pipe showcasing all status actions with 2s spacing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui.utils')*
- `ruff check --no-fix functions/pipes/status_emitter_example/status_emitter_example.py` *(fails: INP001, UP035, ARG002, ANN002, D202)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e0849bf0832e81b51f1a437a5208