### PR TITLE
Initialize error_occurred flag before streaming loop

### DIFF
--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -853,6 +853,7 @@ class Pipe:
 
 
         # Send OpenAI Responses API request, parse and emit response
+        error_occurred = False
         try:
             for loop_idx in range(valves.MAX_FUNCTION_CALL_LOOPS):
                 final_response: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- initialize `error_occurred` flag before running streaming loop so final status emitter is safe

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'open_webui.utils')*


------
https://chatgpt.com/codex/tasks/task_e_68c599340104832eb2f091e0ade44225