### PR TITLE
Remove "web_search_tool" from gpt-5-nano features

### DIFF
--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -61,7 +61,7 @@ class ModelFamily:
 
         "gpt-5":                {"features": {"function_calling","reasoning","reasoning_summary","web_search_tool","image_gen_tool","verbosity"}},
         "gpt-5-mini":           {"features": {"function_calling","reasoning","reasoning_summary","web_search_tool","image_gen_tool","verbosity"}},
-        "gpt-5-nano":           {"features": {"function_calling","reasoning","reasoning_summary","web_search_tool","image_gen_tool","verbosity"}},
+        "gpt-5-nano":           {"features": {"function_calling","reasoning","reasoning_summary","image_gen_tool","verbosity"}},
 
         "gpt-4.1":              {"features": {"function_calling","web_search_tool","image_gen_tool"}},
         "gpt-4.1-mini":         {"features": {"function_calling","web_search_tool","image_gen_tool"}},


### PR DESCRIPTION
Removes "web_search_tool" feature from the gpt-5-nano model. 

https://platform.openai.com/docs/models/gpt-5-nano