### PR TITLE
OpenAI Responses: enable GPT-5 Pro + fixes

### DIFF
--- a/functions/pipes/openai_responses_manifold/CHANGELOG.md
+++ b/functions/pipes/openai_responses_manifold/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the OpenAI Responses Manifold pipeline are documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-10-10
+- Add support for GPT-5 Pro across FEATURE_SUPPORT gates (web_search, image_gen, function_calling,
+  reasoning, reasoning_summary, verbosity).
+- Normalize model IDs to strip any function/module prefixes before sending to OpenAI
+  (prevents model_not_found when IDs like `openai_responses.gpt-5-pro` are used).
+- For GPT-5 family, drop unsupported sampling params (`temperature`, `top_p`) with warnings to
+  avoid 4xx errors.
+- Log full 4xx response bodies for both streaming and non‑streaming requests to aid debugging.
+- Note: deep‑research models (o3-deep-research, o4-mini-deep-research) function as expected in
+  smoke tests, including visible reasoning; they remain marked experimental pending broader
+  validation.
+
 ## [0.8.28] - 2025-08-21
 - Resolved compatibility with Open WebUI v0.6.23 by awaiting `__tools__` when
   it is provided as a coroutine.

--- a/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
+++ b/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
@@ -6,7 +6,7 @@ author_url: https://github.com/jrkropp
 git_url: https://github.com/jrkropp/open-webui-developer-toolkit/blob/main/functions/pipes/openai_responses_manifold/openai_responses_manifold.py
 description: Brings OpenAI Response API support to Open WebUI, enabling features not possible via Completions API.
 required_open_webui_version: 0.6.3
-version: 0.8.28
+version: 0.9.0
 license: MIT
 """
 


### PR DESCRIPTION
This PR makes the OpenAI Responses API manifold work reliably with GPT‑5 Pro (and family) in OpenWebUI.\n\nKey changes\n- Add gpt-5-pro to FEATURE_SUPPORT gates (web_search, image_gen, functions, reasoning, reasoning_summary, verbosity) so the right capabilities surface\n- Normalize model IDs by stripping any function/module prefixes before sending to OpenAI (avoids model_not_found on e.g. openai_responses.* prefixes)\n- For GPT-5 family, drop unsupported sampling params (temperature, top_p) with warnings to prevent 4xx\n- Log full 4xx bodies from streaming and non‑streaming requests for faster diagnosis\n\nNotes\n- Tested locally via OpenWebUI custom function; with GPT‑5 Pro selected, requests now succeed and UI shows reasoning status when configured\n- If you see a 400 regarding reasoning.summary, set REASONING_SUMMARY to "detailed" (or disable) in valves\n- No secrets in code; all behavior is feature-gated by model family\n\nHappy to adjust naming or placement per maintainers’ guidance.